### PR TITLE
feat(indexer): add separate providers folder for testnet

### DIFF
--- a/atp-indexer/bootstrap.sh
+++ b/atp-indexer/bootstrap.sh
@@ -325,6 +325,14 @@ function deploy() {
   fi
 
   yarn install --frozen-lockfile
+
+  # Use providers-testnet folder for testnet, providers for prod
+  if [ "$infra_environment" = "testnet" ]; then
+    export PROVIDERS_DIR="providers-testnet"
+  else
+    export PROVIDERS_DIR="providers"
+  fi
+  log_step "Using providers directory: $PROVIDERS_DIR"
   yarn bootstrap
 
   # Load contract addresses from environment variables or JSON file

--- a/atp-indexer/scripts/aggregate-providers.ts
+++ b/atp-indexer/scripts/aggregate-providers.ts
@@ -103,9 +103,14 @@ function normalizeProvider(metadata: any, filename: string): ProviderMetadata | 
  * Aggregate all provider metadata files into a single JSON file
  */
 function aggregateProviders() {
-  const providersDir = join(__dirname, '../../providers');
+  // Allow overriding the providers directory via environment variable
+  // Defaults to 'providers' for production
+  const providersFolderName = process.env.PROVIDERS_DIR || 'providers';
+  const providersDir = join(__dirname, '../..', providersFolderName);
   const outputDir = join(__dirname, '../src/api/data');
   const outputFile = join(outputDir, 'providers.json');
+
+  console.log(`Using providers directory: ${providersDir}`);
 
   const providerMap = new Map<number, { provider: ProviderMetadata; filename: string }>();
   let skippedCount = 0;

--- a/providers-testnet/README.md
+++ b/providers-testnet/README.md
@@ -1,0 +1,40 @@
+# Providers (Testnet)
+
+Provider metadata for the **testnet** staking dashboard deployment.
+
+> **Note:** This folder is used for testnet deployments. For production providers, see the `providers/` folder.
+
+## File Structure
+
+File name format: `{providerId}-{provider-name}.json`
+
+Example: `1-aztec-foundation.json`
+
+```json
+{
+  "providerId": 1,
+  "providerName": "Aztec Foundation",
+  "providerDescription": "Brief description of the provider",
+  "providerEmail": "contact@provider.com",
+  "providerWebsite": "https://provider.com",
+  "providerLogoUrl": "https://provider.com/logo.png",
+  "discordUsername": "username",
+  "providerSelfStake": ["0x1234...", "0x5678..."]
+}
+```
+
+## Adding a Provider
+
+1. Copy `_example.json` to `{providerId}-{provider-name}.json`
+2. Fill in your details
+3. Submit a pull request
+
+## Rules
+
+**Required:** `providerId` must match on-chain registration and be unique.
+
+**Optional:** All other fields are optional. Invalid or missing fields will display as empty on the dashboard.
+
+**Self-stake:** `providerSelfStake` is an optional array of attester addresses for sequencers the provider directly stakes. Omit this field if empty.
+
+**Duplicates:** If multiple files have the same `providerId`, only the first file (alphabetically) will be used.

--- a/providers-testnet/_example.json
+++ b/providers-testnet/_example.json
@@ -1,0 +1,10 @@
+{
+    "providerId": 0,
+    "providerName": "",
+    "providerDescription": "",
+    "providerEmail": "",
+    "providerWebsite": "",
+    "providerLogoUrl": "",
+    "discordUsername": "",
+    "providerSelfStake": ["0x..."]
+}


### PR DESCRIPTION
## Summary
- Add `providers-testnet/` folder for testnet-specific provider metadata
- Update indexer to dynamically select providers folder based on environment
- Backward compatible with existing production deployments

## Motivation
Closes #5 - Testnet deployments need separate provider metadata from production. This allows different provider configurations for testnet without affecting mainnet.

## Changes

### New Files
- `providers-testnet/_example.json` - Template for testnet providers
- `providers-testnet/README.md` - Documentation (notes testnet-specific usage)

### Modified Files
- `atp-indexer/scripts/aggregate-providers.ts`:
  - Added `PROVIDERS_DIR` environment variable support
  - Defaults to `providers` for backward compatibility
  - Logs which directory is being used

- `atp-indexer/bootstrap.sh`:
  - Sets `PROVIDERS_DIR=providers-testnet` for testnet deployments
  - Sets `PROVIDERS_DIR=providers` for prod deployments

## How It Works
```
testnet deploy  → PROVIDERS_DIR=providers-testnet → reads from /providers-testnet/
prod deploy     → PROVIDERS_DIR=providers        → reads from /providers/
local dev       → PROVIDERS_DIR not set          → defaults to /providers/
```

## Test Plan
- [x] Script syntax validated
- [x] YAML workflow files valid
- [ ] Test testnet deployment uses correct folder
- [ ] Verify prod deployment still works

---
🤖 Generated with [Claude Code](https://claude.ai/code)