### PR TITLE
feat(indexer): add separate providers-testnet folder for testnet depl…

### DIFF
--- a/.github/workflows/deploy-indexer.yaml
+++ b/.github/workflows/deploy-indexer.yaml
@@ -42,6 +42,7 @@ jobs:
       ENV: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
       GREEN: ${{ inputs.green || contains(github.ref, '-green') }}
       DRY_RUN: ${{ inputs.dry_run }}
+      NODE_ENV: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
 
       # AWS Configuration
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}

--- a/atp-indexer/.env.example
+++ b/atp-indexer/.env.example
@@ -17,7 +17,7 @@ ROLLUP_ADDRESS=0x...
 START_BLOCK=0
 
 # Application
-NODE_ENV=development
+NODE_ENV=development # testnet or prod
 LOG_LEVEL=info
 
 # For comparing data from old indexer to ponder (used in scripts/compare-database.ts)

--- a/atp-indexer/scripts/aggregate-providers.ts
+++ b/atp-indexer/scripts/aggregate-providers.ts
@@ -103,7 +103,10 @@ function normalizeProvider(metadata: any, filename: string): ProviderMetadata | 
  * Aggregate all provider metadata files into a single JSON file
  */
 function aggregateProviders() {
-  const providersDir = join(__dirname, '../../providers');
+  // Use providers-testnet for testnet environment, providers for prod/dev
+  const isTestnet = process.env.NODE_ENV === 'testnet';
+  const providersFolderName = isTestnet ? 'providers-testnet' : 'providers';
+  const providersDir = join(__dirname, `../../${providersFolderName}`);
   const outputDir = join(__dirname, '../src/api/data');
   const outputFile = join(outputDir, 'providers.json');
 

--- a/providers-testnet/README.md
+++ b/providers-testnet/README.md
@@ -1,0 +1,38 @@
+# Providers (Testnet)
+
+Provider metadata for the staking dashboard testnet environment.
+
+## File Structure
+
+File name format: `{providerId}-{provider-name}.json`
+
+Example: `1-aztec-foundation.json`
+
+```json
+{
+  "providerId": 1,
+  "providerName": "Aztec Foundation",
+  "providerDescription": "Brief description of the provider",
+  "providerEmail": "contact@provider.com",
+  "providerWebsite": "https://provider.com",
+  "providerLogoUrl": "https://provider.com/logo.png",
+  "discordUsername": "username",
+  "providerSelfStake": ["0x1234...", "0x5678..."]
+}
+```
+
+## Adding a Provider
+
+1. Copy `_example.json` to `{providerId}-{provider-name}.json`
+2. Fill in your details
+3. Submit a pull request
+
+## Rules
+
+**Required:** `providerId` must match on-chain registration and be unique.
+
+**Optional:** All other fields are optional. Invalid or missing fields will display as empty on the dashboard.
+
+**Self-stake:** `providerSelfStake` is an optional array of attester addresses for sequencers the provider directly stakes. Omit this field if empty.
+
+**Duplicates:** If multiple files have the same `providerId`, only the first file (alphabetically) will be used.

--- a/providers-testnet/_example.json
+++ b/providers-testnet/_example.json
@@ -1,0 +1,10 @@
+{
+    "providerId": 0,
+    "providerName": "",
+    "providerDescription": "",
+    "providerEmail": "",
+    "providerWebsite": "",
+    "providerLogoUrl": "",
+    "discordUsername": "",
+    "providerSelfStake": ["0x..."]
+}


### PR DESCRIPTION
## Summary

- Create separate `providers-testnet/` folder for testnet provider metadata
- Update CI/CD to use testnet-specific providers folder when deploying to testnet environment
- Keep `providers/` folder for production deployments

## What Changed

1. **New folder**: `providers-testnet/` - Contains `_example.json` and `README.md` for testnet providers
2. **Updated**: `atp-indexer/scripts/aggregate-providers.ts` - Now uses `providers-testnet/` when `NODE_ENV=testnet`, otherwise uses `providers/`
3. **Updated**: `.github/workflows/deploy-indexer.yaml` - Sets `NODE_ENV` environment variable based on deployment target (testnet/prod)
4. **Updated**: `atp-indexer/.env.example` - Documents `NODE_ENV` options

## Why

Previously, the same `providers/` folder was used for both testnet and production deployments. This created issues because:
- Testnet and mainnet providers have different provider IDs
- Mixing provider data between environments could cause conflicts
- No separation between testnet and production provider metadata

By creating separate folders, we can:
- Maintain distinct provider lists for each environment
- Avoid provider ID conflicts between testnet and mainnet
- Ensure cleaner separation of environments

## How to Test

1. Test locally:
   ```bash
   cd atp-indexer
   NODE_ENV=testnet yarn bootstrap  # Should use providers-testnet/
   NODE_ENV=prod yarn bootstrap      # Should use providers/
   ```

2. Verify the generated `src/api/data/providers.json` uses the correct source folder

3. Deploy to testnet and verify the dashboard loads testnet providers correctly
