### PR TITLE
fix: correct rollupVersion checks 

### DIFF
--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsModal.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsModal.tsx
@@ -342,7 +342,7 @@ export const ATPDetailsModal = ({ atp, isOpen, onClose, onWithdrawSuccess, onRef
                       Error: Staker contract address not found
                     </div>
                   </div>
-                ) : !rollupVersion ? (
+                ) : rollupVersion === undefined ? (
                   <div className="bg-parchment/5 border border-parchment/20 p-4 text-center">
                     <div className="text-sm text-parchment/60">
                       Loading stake details...

--- a/staking-dashboard/src/components/Registration/RegistrationStake.tsx
+++ b/staking-dashboard/src/components/Registration/RegistrationStake.tsx
@@ -116,7 +116,7 @@ export const RegistrationStake = ({ onComplete }: RegistrationStakeProps) => {
 
   const handleAddValidatorToQueue = (index: number) => {
     const keystore = uploadedKeystores[index]
-    if (!rollupVersion === undefined || !selectedAtp || !activationThreshold || completedValidatorsWithQueue.has(keystore.attester)) return
+    if (rollupVersion === undefined || !selectedAtp || !activationThreshold || completedValidatorsWithQueue.has(keystore.attester)) return
 
     const transaction = buildValidatorTransaction(keystore)
     if (!transaction) return
@@ -144,7 +144,7 @@ export const RegistrationStake = ({ onComplete }: RegistrationStakeProps) => {
   }
 
   const handleAddAllToQueue = () => {
-    if (!selectedAtp || !rollupVersion === undefined || uploadedKeystores.length === 0) return
+    if (!selectedAtp || rollupVersion === undefined || uploadedKeystores.length === 0) return
     if (!areAllKeystoresValid) {
       showAlert('error', 'Invalid keystores detected')
       return


### PR DESCRIPTION
Fixed incorrect truthiness checks on rollupVersion that caused "Loading stake details..." to display indefinitely when rollupVersion was 0 (a valid version). Changed from `!rollupVersion to rollupVersion === undefined` to properly distinguish between unloaded state and valid version 0.