### PR TITLE
fix: cap claimable to remaining allocation in overview

### DIFF
--- a/staking-dashboard/src/components/ATPStakingOverview/ATPStakingOverview.tsx
+++ b/staking-dashboard/src/components/ATPStakingOverview/ATPStakingOverview.tsx
@@ -79,7 +79,8 @@ export const ATPStakingOverview = ({ atpData, walletBalance = 0n }: ATPStakingOv
   const totalAtpClaimable = atpData.reduce((sum, atp) => {
     const remainingAllocation = (atp.allocation || 0n) - (atp.totalWithdrawn || 0n)
     if (remainingAllocation <= 0n) return sum
-    return sum + (atp.claimable || 0n)
+    const claimable = atp.claimable || 0n
+    return sum + (claimable > remainingAllocation ? remainingAllocation : claimable)
   }, 0n)
   // Claimable/available includes ATP claimable + ERC20 wallet balance (available to use)
   const totalClaimable = totalAtpClaimable + walletBalance


### PR DESCRIPTION
## Summary
- Fixes the "Unlocked" percentage showing >100% (e.g., 168%) in the Total Allocation overview
- Fixes the "Locked" amount showing negative values (e.g., -1,000,000 STK)

## Problem
When users withdraw tokens from their ATP vaults, the `atp.claimable` value from the API wasn't being capped to the remaining allocation. This caused:
- `totalAtpClaimable` to exceed `totalAtpAllocation`
- The unlocked percentage to exceed 100%
- The locked calculation to go negative

## Solution
Cap each ATP's claimable to its `remainingAllocation` (allocation - totalWithdrawn) before summing.

## Test plan
- [x] Verify user with withdrawn tokens no longer sees >100% unlocked percentage
- [x] Verify locked amount is no longer negative