### PR TITLE
feat(providers): add Obsidian Staking provider metadata

### DIFF
--- a/providers/98-obsidian-staking.json
+++ b/providers/98-obsidian-staking.json
@@ -1,0 +1,9 @@
+{
+  "providerId": 98,
+  "providerName": "Obsidian Staking",
+  "providerDescription": "Independent sequencer operated with conviction. Because privacy infrastructure should be accessible, not extractive.",
+  "providerEmail": "hello@zkobsidian.xyz",
+  "providerWebsite": "https://zkobsidian.xyz",
+  "providerLogoUrl": "https://zkobsidian.xyz/obsidian-staking-logo.svg",
+  "discordUsername": "zkobsidian"
+}


### PR DESCRIPTION
## Provider 98 Metadata: Obsidian Staking

Adding provider metadata for **Obsidian Staking** (Provider ID: 98) to the staking dashboard.

**Registration tx:** [`0xf904c87d673989a013c90ffb5ea2295ce0b00c4b781060875c76db4ce4e2cd9c`](https://etherscan.io/tx/0xf904c87d673989a013c90ffb5ea2295ce0b00c4b781060875c76db4ce4e2cd9c)
**Keystore queue tx:** [`0x9306d97726ddb0665b2373b9a24e262390003d344a23ba9a51ec83fb2fca8df8`](https://etherscan.io/tx/0x9306d97726ddb0665b2373b9a24e262390003d344a23ba9a51ec83fb2fca8df8)

**Website:** https://zkobsidian.xyz
**Logo:** https://zkobsidian.xyz/obsidian-staking-logo.svg

Submitted as requested by @saleel via email.