### PR TITLE
Provider 96 Metadata (axol.io)

### DIFF
--- a/providers/96-axol-io.json
+++ b/providers/96-axol-io.json
@@ -1,0 +1,9 @@
+{
+  "providerId": 96,
+  "providerName": "axol.io",
+  "providerDescription": "axolotls running blockchains",
+  "providerEmail": "drew@axol.io",
+  "providerWebsite": "https://axol.io",
+  "providerLogoUrl": "https://raw.githubusercontent.com/axol-io/brand-identity/master/assets/logos/internal/png/circle-logos-png/Logo-light-background-1.png",
+  "discordUsername": "mf_droo"
+}


### PR DESCRIPTION
## Summary

Add metadata for Provider 96 (axol.io).

Registration tx: https://etherscan.io/tx/0xd4034560ab83cca2bf3929486d59a4fd2d82236c8f4af5b61d61faa15d50274d