### PR TITLE
fix: query correct rollup for legacy delegation withdrawals

### DIFF
--- a/atp-indexer/src/api/handlers/atp/details.ts
+++ b/atp-indexer/src/api/handlers/atp/details.ts
@@ -63,6 +63,7 @@ function formatDelegations(
         providerName: metadata?.providerName || `Provider ${providerId}`,
         providerLogo: metadata?.providerLogoUrl || '',
         operatorAddress: checksumAddress(op.attesterAddress),
+        rollupAddress: checksumAddress(op.rollupAddress),
         stakedAmount: activationThreshold,
         totalSlashed: totalSlashed.toString(),
         splitContract: checksumAddress(op.splitContractAddress),

--- a/atp-indexer/src/api/handlers/atp/details.ts
+++ b/atp-indexer/src/api/handlers/atp/details.ts
@@ -29,6 +29,7 @@ function formatDirectStakes(
     return {
       attesterAddress: checksumAddress(stake.attesterAddress),
       operatorAddress: checksumAddress(stake.operatorAddress),
+      rollupAddress: checksumAddress(stake.rollupAddress),
       stakedAmount: activationThreshold,
       totalSlashed: totalSlashed.toString(),
       txHash: stake.txHash,

--- a/atp-indexer/src/api/handlers/staking/beneficiary-overview.ts
+++ b/atp-indexer/src/api/handlers/staking/beneficiary-overview.ts
@@ -129,6 +129,7 @@ export async function handleBeneficiaryStakingOverview(c: Context): Promise<Resp
     const directStakeBreakdown = markedDirectStakes.map(stake => ({
       atpAddress: checksumAddress(atpByStaker.get(stake.stakerAddress.toLowerCase()) || stake.atpAddress),
       attesterAddress: checksumAddress(stake.attesterAddress),
+      rollupAddress: checksumAddress(stake.rollupAddress),
       stakedAmount: stake.stakedAmount.toString(),
       hasFailedDeposit: stake.hasFailedDeposit,
       failedDepositTxHash: stake.failedDepositTxHash,
@@ -150,6 +151,7 @@ export async function handleBeneficiaryStakingOverview(c: Context): Promise<Resp
         providerName: metadata?.providerName || `Provider ${providerId}`,
         providerLogo: metadata?.providerLogoUrl || '',
         attesterAddress: checksumAddress(delegation.attesterAddress),
+        rollupAddress: checksumAddress(delegation.rollupAddress),
         stakedAmount: delegation.stakedAmount.toString(),
         splitContract: checksumAddress(delegation.splitContractAddress),
         providerTakeRate: delegation.providerTakeRate,
@@ -174,6 +176,7 @@ export async function handleBeneficiaryStakingOverview(c: Context): Promise<Resp
         providerName: metadata?.providerName || `Provider ${providerId}`,
         providerLogo: metadata?.providerLogoUrl || '',
         attesterAddress: checksumAddress(delegation.attesterAddress),
+        rollupAddress: checksumAddress(delegation.rollupAddress),
         stakedAmount: delegation.stakedAmount.toString(),
         splitContract: checksumAddress(delegation.splitContractAddress),
         providerTakeRate: delegation.providerTakeRate,
@@ -192,6 +195,7 @@ export async function handleBeneficiaryStakingOverview(c: Context): Promise<Resp
     const erc20DirectStakeBreakdown = markedErc20DirectDeposits.map(dep => ({
       attesterAddress: checksumAddress(dep.attesterAddress),
       withdrawerAddress: checksumAddress(dep.withdrawerAddress),
+      rollupAddress: checksumAddress(dep.rollupAddress),
       stakedAmount: dep.amount.toString(),
       txHash: dep.txHash,
       timestamp: Number(dep.timestamp),

--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDelegationItem.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDelegationItem.tsx
@@ -60,7 +60,8 @@ export const ATPDetailsDelegationItem = ({
   const { getSplitStatus, claimAllHook } = useClaimAllContext()
   const { isRewardsClaimable } = useIsRewardsClaimable()
 
-  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(delegation.operatorAddress as Address)
+  const delegationRollupAddress = delegation.rollupAddress as Address
+  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(delegation.operatorAddress as Address, delegationRollupAddress)
   const { withdrawalDelayDays } = useGovernanceConfig()
 
   const {
@@ -487,6 +488,7 @@ export const ATPDetailsDelegationItem = ({
                     stakerAddress={stakerAddress}
                     attesterAddress={delegation.operatorAddress as Address}
                     rollupVersion={rollupVersion}
+                    rollupAddress={delegationRollupAddress}
                     status={status}
                     canFinalize={canFinalize}
                     actualUnlockTime={actualUnlockTime}

--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDelegationItem.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDelegationItem.tsx
@@ -73,7 +73,7 @@ export const ATPDetailsDelegationItem = ({
     isAtRisk,
     isCritical,
     isLoading: isLoadingHealth
-  } = useStakeHealth(delegation.operatorAddress as Address)
+  } = useStakeHealth(delegation.operatorAddress as Address, delegationRollupAddress)
 
   const splitStatus = getSplitStatus(delegation.splitContract as Address)
   const isInBatch = splitStatus !== 'idle'

--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDirectStakeItem.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDirectStakeItem.tsx
@@ -56,7 +56,7 @@ export const ATPDetailsDirectStakeItem = ({ stake, stakerAddress, rollupVersion,
     isAtRisk,
     isCritical,
     isLoading: isLoadingHealth
-  } = useStakeHealth(stake.attesterAddress as Address)
+  } = useStakeHealth(stake.attesterAddress as Address, stakeRollupAddress)
 
   const isUnstaked = stake.status === 'UNSTAKED'
   const isInQueue = status === SequencerStatus.NONE && !stake.hasFailedDeposit && !isUnstaked

--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDirectStakeItem.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsDirectStakeItem.tsx
@@ -43,7 +43,8 @@ export const ATPDetailsDirectStakeItem = ({ stake, stakerAddress, rollupVersion,
   const { date, time } = formatBlockTimestamp(stake.timestamp)
   const { isRewardsClaimable } = useIsRewardsClaimable()
 
-  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(stake.attesterAddress as Address)
+  const stakeRollupAddress = stake.rollupAddress as Address
+  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(stake.attesterAddress as Address, stakeRollupAddress)
   const { withdrawalDelayDays } = useGovernanceConfig()
 
   const {
@@ -389,6 +390,7 @@ export const ATPDetailsDirectStakeItem = ({ stake, stakerAddress, rollupVersion,
                     stakerAddress={stakerAddress}
                     attesterAddress={stake.attesterAddress as Address}
                     rollupVersion={rollupVersion}
+                    rollupAddress={stakeRollupAddress}
                     status={status}
                     canFinalize={canFinalize}
                     actualUnlockTime={actualUnlockTime}

--- a/staking-dashboard/src/components/ATPDetailsModal/WithdrawalActions.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/WithdrawalActions.tsx
@@ -75,7 +75,7 @@ interface WithdrawalActionsProps {
   stakerAddress: Address;
   attesterAddress: Address;
   rollupVersion: bigint;
-  rollupAddress?: Address;
+  rollupAddress: Address;
   status: number | undefined;
   canFinalize: boolean;
   actualUnlockTime?: bigint;

--- a/staking-dashboard/src/components/ATPDetailsModal/WithdrawalActions.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/WithdrawalActions.tsx
@@ -75,6 +75,7 @@ interface WithdrawalActionsProps {
   stakerAddress: Address;
   attesterAddress: Address;
   rollupVersion: bigint;
+  rollupAddress?: Address;
   status: number | undefined;
   canFinalize: boolean;
   actualUnlockTime?: bigint;
@@ -94,6 +95,7 @@ export const WithdrawalActions = ({
   stakerAddress,
   attesterAddress,
   rollupVersion,
+  rollupAddress,
   status,
   canFinalize,
   actualUnlockTime,
@@ -186,7 +188,7 @@ export const WithdrawalActions = ({
 
   const handleFinalizeWithdraw = async () => {
     try {
-      await finalizeWithdraw(attesterAddress);
+      await finalizeWithdraw(attesterAddress, rollupAddress);
     } catch (error) {
       console.error("Failed to finalize withdraw:", error);
     }

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDelegationItem.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDelegationItem.tsx
@@ -58,7 +58,7 @@ export const WalletDelegationItem = ({
     isAtRisk,
     isCritical,
     isLoading: isLoadingHealth
-  } = useStakeHealth(delegation.attesterAddress as Address)
+  } = useStakeHealth(delegation.attesterAddress as Address, delegationRollupAddress)
 
   const splitStatus = getSplitStatus(delegation.splitContract as Address)
   const isInBatch = splitStatus !== 'idle'

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDelegationItem.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDelegationItem.tsx
@@ -45,7 +45,8 @@ export const WalletDelegationItem = ({
   const { getSplitStatus, claimAllHook } = useClaimAllContext()
   const { isRewardsClaimable } = useIsRewardsClaimable()
 
-  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(delegation.attesterAddress as Address)
+  const delegationRollupAddress = delegation.rollupAddress as Address
+  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(delegation.attesterAddress as Address, delegationRollupAddress)
   const { withdrawalDelayDays } = useGovernanceConfig()
 
   const {
@@ -380,6 +381,7 @@ export const WalletDelegationItem = ({
                   <WalletWithdrawalActions
                     attesterAddress={delegation.attesterAddress as Address}
                     recipientAddress={address}
+                    rollupAddress={delegationRollupAddress}
                     status={status}
                     canFinalize={canFinalize}
                     actualUnlockTime={actualUnlockTime}

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDirectStakeItem.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDirectStakeItem.tsx
@@ -47,7 +47,7 @@ export const WalletDirectStakeItem = ({
     isAtRisk,
     isCritical,
     isLoading: isLoadingHealth
-  } = useStakeHealth(stake.attesterAddress as Address)
+  } = useStakeHealth(stake.attesterAddress as Address, stakeRollupAddress)
 
   const isUnstaked = stake.status === 'UNSTAKED'
   const isInQueue = status === SequencerStatus.NONE && !stake.hasFailedDeposit && !isUnstaked

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDirectStakeItem.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletDirectStakeItem.tsx
@@ -34,7 +34,8 @@ export const WalletDirectStakeItem = ({
   const { symbol, decimals } = useStakingAssetTokenDetails()
   const { date, time } = formatBlockTimestamp(stake.timestamp)
 
-  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(stake.attesterAddress as Address)
+  const stakeRollupAddress = stake.rollupAddress as Address
+  const { status, statusLabel, isLoading: isLoadingStatus, canFinalize, actualUnlockTime, refetch: refetchStatus } = useSequencerStatus(stake.attesterAddress as Address, stakeRollupAddress)
   const { withdrawalDelayDays } = useGovernanceConfig()
 
   const {
@@ -248,6 +249,7 @@ export const WalletDirectStakeItem = ({
                   <WalletWithdrawalActions
                     attesterAddress={stake.attesterAddress as Address}
                     recipientAddress={address}
+                    rollupAddress={stakeRollupAddress}
                     status={status}
                     canFinalize={canFinalize}
                     actualUnlockTime={actualUnlockTime}

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
@@ -64,6 +64,7 @@ function parseContractError(error: Error): string {
 interface WalletWithdrawalActionsProps {
   attesterAddress: Address
   recipientAddress: Address
+  rollupAddress?: Address
   status: number | undefined
   canFinalize: boolean
   actualUnlockTime?: bigint
@@ -78,6 +79,7 @@ interface WalletWithdrawalActionsProps {
 export const WalletWithdrawalActions = ({
   attesterAddress,
   recipientAddress,
+  rollupAddress,
   status,
   canFinalize,
   actualUnlockTime,
@@ -157,7 +159,7 @@ export const WalletWithdrawalActions = ({
 
   const handleFinalizeWithdraw = async () => {
     try {
-      await finalizeWithdraw(attesterAddress)
+      await finalizeWithdraw(attesterAddress, rollupAddress)
     } catch (error) {
       console.error("Failed to finalize withdraw:", error)
     }

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
@@ -64,7 +64,7 @@ function parseContractError(error: Error): string {
 interface WalletWithdrawalActionsProps {
   attesterAddress: Address
   recipientAddress: Address
-  rollupAddress?: Address
+  rollupAddress: Address
   status: number | undefined
   canFinalize: boolean
   actualUnlockTime?: bigint

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletWithdrawalActions.tsx
@@ -151,7 +151,7 @@ export const WalletWithdrawalActions = ({
 
   const handleInitiateWithdraw = async () => {
     try {
-      await initiateWithdraw(attesterAddress, recipientAddress)
+      await initiateWithdraw(attesterAddress, recipientAddress, rollupAddress)
     } catch (error) {
       console.error("Failed to initiate withdraw:", error)
     }

--- a/staking-dashboard/src/hooks/atp/useATPDetails.ts
+++ b/staking-dashboard/src/hooks/atp/useATPDetails.ts
@@ -21,6 +21,7 @@ export interface Delegation {
   providerName?: string
   providerLogo?: string
   operatorAddress: string
+  rollupAddress: string
   splitContract: string
   providerTakeRate: number
   providerRewardsRecipient: string

--- a/staking-dashboard/src/hooks/atp/useATPDetails.ts
+++ b/staking-dashboard/src/hooks/atp/useATPDetails.ts
@@ -6,6 +6,7 @@ import { stringToBigInt } from '@/utils/atpFormatters'
 export interface DirectStake {
   attesterAddress: string
   operatorAddress: string
+  rollupAddress: string
   stakedAmount: bigint
   txHash: string
   timestamp: string

--- a/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
+++ b/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
@@ -20,6 +20,7 @@ import {
 export interface DirectStakeBreakdown {
   atpAddress: Address
   attesterAddress: Address
+  rollupAddress: Address
   stakedAmount: bigint
   hasFailedDeposit: boolean
   failedDepositTxHash: string | null
@@ -41,6 +42,7 @@ export interface DelegationBreakdown {
   providerName?: string
   providerLogo?: string
   attesterAddress: Address
+  rollupAddress: Address
   stakedAmount: bigint
   rewards: bigint
   splitContract: Address
@@ -60,6 +62,7 @@ export interface Erc20DelegationBreakdown {
   providerName?: string
   providerLogo?: string
   attesterAddress: Address
+  rollupAddress: Address
   stakedAmount: bigint
   rewards: bigint
   splitContract: Address
@@ -77,6 +80,7 @@ export interface Erc20DelegationBreakdown {
 export interface Erc20DirectStakeBreakdown {
   attesterAddress: Address
   withdrawerAddress: Address
+  rollupAddress: Address
   stakedAmount: bigint
   hasFailedDeposit: boolean
   failedDepositTxHash: string | null
@@ -109,6 +113,7 @@ export interface AggregatedStakingData {
 interface ApiDirectStake {
   atpAddress: string
   attesterAddress: string
+  rollupAddress: string
   stakedAmount: string
   hasFailedDeposit: boolean
   failedDepositTxHash: string | null
@@ -130,6 +135,7 @@ interface ApiDelegation {
   providerName?: string
   providerLogo?: string
   attesterAddress: string
+  rollupAddress: string
   stakedAmount: string
   splitContract: string
   providerTakeRate: number
@@ -148,6 +154,7 @@ interface ApiErc20Delegation {
   providerName?: string
   providerLogo?: string
   attesterAddress: string
+  rollupAddress: string
   stakedAmount: string
   splitContract: string
   providerTakeRate: number
@@ -164,6 +171,7 @@ interface ApiErc20Delegation {
 interface ApiErc20DirectStake {
   attesterAddress: string
   withdrawerAddress: string
+  rollupAddress: string
   stakedAmount: string
   hasFailedDeposit: boolean
   failedDepositTxHash: string | null
@@ -207,6 +215,7 @@ function parseDirectStake(stake: ApiDirectStake): DirectStakeBreakdown {
   return {
     atpAddress: stake.atpAddress as Address,
     attesterAddress: stake.attesterAddress as Address,
+    rollupAddress: stake.rollupAddress as Address,
     stakedAmount: stringToBigInt(stake.stakedAmount),
     hasFailedDeposit: stake.hasFailedDeposit,
     failedDepositTxHash: stake.failedDepositTxHash,
@@ -267,6 +276,7 @@ function parseDelegation(
     providerName: delegation.providerName,
     providerLogo: delegation.providerLogo,
     attesterAddress: delegation.attesterAddress as Address,
+    rollupAddress: delegation.rollupAddress as Address,
     stakedAmount: stringToBigInt(delegation.stakedAmount),
     rewards: delegation.hasFailedDeposit ? 0n : userRewards,
     splitContract: delegation.splitContract as Address,
@@ -324,6 +334,7 @@ function parseErc20Delegation(
     providerName: delegation.providerName,
     providerLogo: delegation.providerLogo,
     attesterAddress: delegation.attesterAddress as Address,
+    rollupAddress: delegation.rollupAddress as Address,
     stakedAmount: stringToBigInt(delegation.stakedAmount),
     rewards: delegation.hasFailedDeposit ? 0n : userRewards,
     splitContract: delegation.splitContract as Address,
@@ -346,6 +357,7 @@ function parseErc20DirectStake(stake: ApiErc20DirectStake): Erc20DirectStakeBrea
   return {
     attesterAddress: stake.attesterAddress as Address,
     withdrawerAddress: stake.withdrawerAddress as Address,
+    rollupAddress: stake.rollupAddress as Address,
     stakedAmount: stringToBigInt(stake.stakedAmount),
     hasFailedDeposit: stake.hasFailedDeposit,
     failedDepositTxHash: stake.failedDepositTxHash,
@@ -502,6 +514,7 @@ export const useAggregatedStakingData = (): AggregatedStakingData => {
       .map(stake => ({
         attesterAddress: stake.attesterAddress,
         withdrawerAddress: stake.withdrawerAddress,
+        rollupAddress: contracts.rollup.address,
         stakedAmount: BigInt(stake.stakedAmount),
         hasFailedDeposit: false,
         failedDepositTxHash: null,

--- a/staking-dashboard/src/hooks/rollup/useAttesterView.ts
+++ b/staking-dashboard/src/hooks/rollup/useAttesterView.ts
@@ -3,23 +3,24 @@ import type { Address } from "viem"
 import { contracts } from "@/contracts"
 
 /**
- * Hook to get comprehensive attester/sequencer information including status, balance, and exit details
+ * Hook to get comprehensive attester/sequencer information including status, balance, and exit details.
+ *
+ * `rollupAddress` is required (but may be undefined while the caller's data is still
+ * loading). A legacy-rollup stake queried against the current canonical rollup returns
+ * status=NONE and strands users in "IN QUEUE" with no finalize button — so there is
+ * deliberately no silent fallback to `contracts.rollup.address`.
  */
 export function useAttesterView(
   attesterAddress: Address | undefined,
-  rollupAddress?: Address,
+  rollupAddress: Address | undefined,
 ) {
-  // Delegations on a legacy rollup must be queried against their own rollup,
-  // not the current canonical one, or getAttesterView returns status=NONE and
-  // the UI strands the user in "IN QUEUE" with no finalize button.
-  const address = rollupAddress ?? contracts.rollup.address
   const { data, isLoading, error, refetch } = useReadContract({
-    address,
+    address: rollupAddress,
     abi: contracts.rollup.abi,
     functionName: "getAttesterView",
     args: attesterAddress ? [attesterAddress] : undefined,
     query: {
-      enabled: !!attesterAddress,
+      enabled: !!attesterAddress && !!rollupAddress,
     },
   })
 

--- a/staking-dashboard/src/hooks/rollup/useAttesterView.ts
+++ b/staking-dashboard/src/hooks/rollup/useAttesterView.ts
@@ -5,9 +5,16 @@ import { contracts } from "@/contracts"
 /**
  * Hook to get comprehensive attester/sequencer information including status, balance, and exit details
  */
-export function useAttesterView(attesterAddress: Address | undefined) {
+export function useAttesterView(
+  attesterAddress: Address | undefined,
+  rollupAddress?: Address,
+) {
+  // Delegations on a legacy rollup must be queried against their own rollup,
+  // not the current canonical one, or getAttesterView returns status=NONE and
+  // the UI strands the user in "IN QUEUE" with no finalize button.
+  const address = rollupAddress ?? contracts.rollup.address
   const { data, isLoading, error, refetch } = useReadContract({
-    address: contracts.rollup.address,
+    address,
     abi: contracts.rollup.abi,
     functionName: "getAttesterView",
     args: attesterAddress ? [attesterAddress] : undefined,

--- a/staking-dashboard/src/hooks/rollup/useFinalizeWithdraw.ts
+++ b/staking-dashboard/src/hooks/rollup/useFinalizeWithdraw.ts
@@ -19,10 +19,10 @@ export function useFinalizeWithdraw() {
   })
 
   return {
-    finalizeWithdraw: (attesterAddress: Address, rollupAddress?: Address) => {
+    finalizeWithdraw: (attesterAddress: Address, rollupAddress: Address) => {
       return write.writeContract({
         abi: contracts.rollup.abi,
-        address: rollupAddress ?? contracts.rollup.address,
+        address: rollupAddress,
         functionName: "finalizeWithdraw",
         args: [attesterAddress]
       })

--- a/staking-dashboard/src/hooks/rollup/useFinalizeWithdraw.ts
+++ b/staking-dashboard/src/hooks/rollup/useFinalizeWithdraw.ts
@@ -19,10 +19,10 @@ export function useFinalizeWithdraw() {
   })
 
   return {
-    finalizeWithdraw: (attesterAddress: Address) => {
+    finalizeWithdraw: (attesterAddress: Address, rollupAddress?: Address) => {
       return write.writeContract({
         abi: contracts.rollup.abi,
-        address: contracts.rollup.address,
+        address: rollupAddress ?? contracts.rollup.address,
         functionName: "finalizeWithdraw",
         args: [attesterAddress]
       })

--- a/staking-dashboard/src/hooks/rollup/useSequencerStatus.ts
+++ b/staking-dashboard/src/hooks/rollup/useSequencerStatus.ts
@@ -44,7 +44,7 @@ export function getStatusLabel(status: number | undefined): string {
  */
 export function useSequencerStatus(
   sequencerAddress: Address | undefined,
-  rollupAddress?: Address,
+  rollupAddress: Address | undefined,
 ) {
   const { status, effectiveBalance, exit, isLoading, error, refetch } =
     useAttesterView(sequencerAddress, rollupAddress);

--- a/staking-dashboard/src/hooks/rollup/useSequencerStatus.ts
+++ b/staking-dashboard/src/hooks/rollup/useSequencerStatus.ts
@@ -42,9 +42,12 @@ export function getStatusLabel(status: number | undefined): string {
  * @param sequencerAddress - The address of the sequencer
  * @returns Sequencer status, label, and related information
  */
-export function useSequencerStatus(sequencerAddress: Address | undefined) {
+export function useSequencerStatus(
+  sequencerAddress: Address | undefined,
+  rollupAddress?: Address,
+) {
   const { status, effectiveBalance, exit, isLoading, error, refetch } =
-    useAttesterView(sequencerAddress);
+    useAttesterView(sequencerAddress, rollupAddress);
 
   // Query the governance withdrawal to get the REAL unlock time
   const { withdrawal, isLoading: isLoadingWithdrawal } = useGovernanceWithdrawal(exit?.withdrawalId);

--- a/staking-dashboard/src/hooks/rollup/useStakeHealth.ts
+++ b/staking-dashboard/src/hooks/rollup/useStakeHealth.ts
@@ -28,9 +28,12 @@ const SLASH_AMOUNT = 2000n * 10n ** 18n
  * - isAtRisk: healthPercentage < 50 (has been slashed significantly)
  * - isCritical: effectiveBalance <= ejectionThreshold (imminent ejection)
  */
-export function useStakeHealth(attesterAddress: Address | undefined) {
+export function useStakeHealth(
+  attesterAddress: Address | undefined,
+  rollupAddress: Address | undefined,
+) {
   const { effectiveBalance, status, isLoading: isLoadingAttester, error: attesterError, refetch: refetchAttester } =
-    useAttesterView(attesterAddress)
+    useAttesterView(attesterAddress, rollupAddress)
 
   const { ejectionThreshold, isLoading: isLoadingEjection, error: ejectionError, refetch: refetchEjection } =
     useEjectionThreshold()

--- a/staking-dashboard/src/hooks/rollup/useWalletInitiateWithdraw.ts
+++ b/staking-dashboard/src/hooks/rollup/useWalletInitiateWithdraw.ts
@@ -18,10 +18,10 @@ export function useWalletInitiateWithdraw() {
     hash,
   })
 
-  const initiateWithdraw = (attesterAddress: Address, recipientAddress: Address) => {
+  const initiateWithdraw = (attesterAddress: Address, recipientAddress: Address, rollupAddress?: Address) => {
     return writeContract({
       abi: contracts.rollup.abi,
-      address: contracts.rollup.address,
+      address: rollupAddress ?? contracts.rollup.address,
       functionName: "initiateWithdraw",
       args: [attesterAddress, recipientAddress],
     })

--- a/staking-dashboard/src/hooks/rollup/useWalletInitiateWithdraw.ts
+++ b/staking-dashboard/src/hooks/rollup/useWalletInitiateWithdraw.ts
@@ -18,10 +18,10 @@ export function useWalletInitiateWithdraw() {
     hash,
   })
 
-  const initiateWithdraw = (attesterAddress: Address, recipientAddress: Address, rollupAddress?: Address) => {
+  const initiateWithdraw = (attesterAddress: Address, recipientAddress: Address, rollupAddress: Address) => {
     return writeContract({
       abi: contracts.rollup.abi,
-      address: rollupAddress ?? contracts.rollup.address,
+      address: rollupAddress,
       functionName: "initiateWithdraw",
       args: [attesterAddress, recipientAddress],
     })


### PR DESCRIPTION
## Problem

Users with delegations on the legacy v0 Rollup see their unstake stuck as **IN QUEUE** with no Finalize Withdraw button. The dashboard hard-codes the current rollup everywhere, so `getAttesterView` returns `status=NONE` and `finalizeWithdraw` would target the wrong contract.

## Fix

Thread each stake's own `rollupAddress` (already stored in the indexer's `staked` / `stakedWithProvider` / `erc20StakedWithProvider` / `deposit` tables) through the API into `useAttesterView`, `useSequencerStatus`, and `useFinalizeWithdraw`. Covers both the ATP Details modal and the Wallet Stakes modal, delegations and direct stakes.

Hooks fall back to the current rollup when no address is passed, so nothing else needs to change.

## Deploy

- **Indexer:** restart only. No schema change, no reindex.
- **Frontend:** standard deploy.

## Test plan

- [ ] After deploy, `/api/atp/:atp/details` and `/api/staking/:beneficiary` responses include `rollupAddress` on every stake/delegation entry
- [ ] Open ATP Details modal for an affected wallet (`0xc1c4…`, `0x5E11…`): badge flips IN QUEUE → Exiting/Unstaking, Finalize Withdraw enables
- [ ] Clicking Finalize Withdraw sends the tx to v0 Rollup `0x603bb2c0…`, not the current rollup
- [ ] Current-rollup delegations / stakes still behave normally