### PR TITLE
fix: warn about pending governance withdrawals on vault card

### DIFF
--- a/staking-dashboard/src/components/ATPStakingCard/ATPStakingCard.tsx
+++ b/staking-dashboard/src/components/ATPStakingCard/ATPStakingCard.tsx
@@ -16,7 +16,7 @@ import { useStakerBalance } from "@/hooks/staker/useStakerBalance";
 import { useNCStakerStatus } from "@/hooks/staker/useNCStakerStatus";
 import { useBlockTimestamp } from "@/hooks/useBlockTimestamp";
 import { usePendingWithdrawals } from "@/hooks/governance";
-import { EXTERNAL_GOVERNANCE_FRONTENDS } from "@/config/externalGovernance";
+import { ExternalGovernanceModal } from "@/components/ExternalGovernanceModal";
 import { useTransactionCart } from "@/contexts/TransactionCartContext";
 import {
   ATPStakingStepsWithTransaction,
@@ -201,9 +201,7 @@ export const ATPStakingCard = ({
     (sum, w) => sum + w.amount,
     0n
   );
-  const governanceDashboardUrl = EXTERNAL_GOVERNANCE_FRONTENDS.find(
-    (f) => f.url
-  )?.url;
+  const [isGovernanceModalOpen, setIsGovernanceModalOpen] = useState(false);
 
   const globalLockTimeDisplay = getTimeToClaimForATP(data, blockTimestamp);
   const { activationThreshold } = useRollupData();
@@ -790,20 +788,14 @@ export const ATPStakingCard = ({
             >
               <div className="text-xs text-amber-400 mt-1">
                 +{formatTokenAmount(pendingGovernanceAmount, decimals, symbol)}{" "}
-                in governance
-                {governanceDashboardUrl && (
-                  <>
-                    {" — "}
-                    <a
-                      href={governanceDashboardUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline hover:text-amber-300"
-                    >
-                      finalize in dashboard
-                    </a>
-                  </>
-                )}
+                in governance{" — "}
+                <button
+                  type="button"
+                  onClick={() => setIsGovernanceModalOpen(true)}
+                  className="underline hover:text-amber-300"
+                >
+                  finalize in dashboard
+                </button>
               </div>
             </Tooltip>
           )}
@@ -837,6 +829,11 @@ export const ATPStakingCard = ({
         onWithdrawSuccess={onClaimSuccess}
         onRefetchAllowance={refetchAllowance}
         onUpgradeSuccess={refetchNCStatus}
+      />
+
+      <ExternalGovernanceModal
+        isOpen={isGovernanceModalOpen}
+        onClose={() => setIsGovernanceModalOpen(false)}
       />
     </div>
   );

--- a/staking-dashboard/src/components/ATPStakingCard/ATPStakingCard.tsx
+++ b/staking-dashboard/src/components/ATPStakingCard/ATPStakingCard.tsx
@@ -15,6 +15,8 @@ import { useRollupData } from "@/hooks/rollup/useRollupData";
 import { useStakerBalance } from "@/hooks/staker/useStakerBalance";
 import { useNCStakerStatus } from "@/hooks/staker/useNCStakerStatus";
 import { useBlockTimestamp } from "@/hooks/useBlockTimestamp";
+import { usePendingWithdrawals } from "@/hooks/governance";
+import { EXTERNAL_GOVERNANCE_FRONTENDS } from "@/config/externalGovernance";
 import { useTransactionCart } from "@/contexts/TransactionCartContext";
 import {
   ATPStakingStepsWithTransaction,
@@ -188,6 +190,20 @@ export const ATPStakingCard = ({
   } = useATPClaim(data);
   // Get cached block timestamp for withdrawal eligibility check (refreshes every 60s)
   const { blockTimestamp } = useBlockTimestamp();
+
+  // Pending governance withdrawals for this vault. Tokens initiated for
+  // withdrawal from Governance stay with the Governance contract until
+  // finalize() is called — they are NOT in the vault, so a vault withdrawal
+  // (vault → wallet) cannot release them. Users often miss this step.
+  const { pendingWithdrawals: governancePendingWithdrawals } =
+    usePendingWithdrawals({ userAddress: data.atpAddress as Address });
+  const pendingGovernanceAmount = governancePendingWithdrawals.reduce(
+    (sum, w) => sum + w.amount,
+    0n
+  );
+  const governanceDashboardUrl = EXTERNAL_GOVERNANCE_FRONTENDS.find(
+    (f) => f.url
+  )?.url;
 
   const globalLockTimeDisplay = getTimeToClaimForATP(data, blockTimestamp);
   const { activationThreshold } = useRollupData();
@@ -705,7 +721,7 @@ export const ATPStakingCard = ({
               Available to Withdraw
             </div>
             <TooltipIcon
-              content="Amount of vested tokens currently available to withdraw from your Token Vault. These tokens have completed their lock period and can be withdrawn."
+              content="Vested tokens in your Token Vault, ready to withdraw to your wallet. Tokens in Governance don't count — finalize any pending governance withdrawals first to bring them back to the vault."
               size="sm"
               maxWidth="max-w-xs"
             />
@@ -766,6 +782,31 @@ export const ATPStakingCard = ({
               </button>
             )}
           </div>
+          {!isFullyWithdrawn && pendingGovernanceAmount > 0n && (
+            <Tooltip
+              content="These tokens are in the Governance contract. Finalize them to return them to your Token Vault before you can withdraw to your wallet."
+              position="top"
+              maxWidth="max-w-xs"
+            >
+              <div className="text-xs text-amber-400 mt-1">
+                +{formatTokenAmount(pendingGovernanceAmount, decimals, symbol)}{" "}
+                in governance
+                {governanceDashboardUrl && (
+                  <>
+                    {" — "}
+                    <a
+                      href={governanceDashboardUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-amber-300"
+                    >
+                      finalize in dashboard
+                    </a>
+                  </>
+                )}
+              </div>
+            </Tooltip>
+          )}
         </div>
 
         {/* Withdrawn */}


### PR DESCRIPTION
Users often try to withdraw from a Token Vault to their wallet while they still have unfinalized governance withdrawals. Until those are finalized, the tokens are held by the Governance contract and cannot be released by a vault withdrawal.

This adds an amber line on the Token Vault card linking directly to the governance dashboard to finalize, and clarifies the "Available to Withdraw" tooltip.