### PR TITLE
Provider list: align page 1 row count, make top-group fold both ways

### DIFF
--- a/staking-dashboard/src/components/Provider/ProviderTable.tsx
+++ b/staking-dashboard/src/components/Provider/ProviderTable.tsx
@@ -208,11 +208,16 @@ export const ProviderTable = ({
     setIsGroupExpanded(false)
   }, [topGroupSize])
 
-  const shouldShowGroup = topGroupSize > 0 && providers.length > topGroupSize && !isGroupExpanded
-  const groupProviders = shouldShowGroup ? providers.slice(0, topGroupSize) : []
-  const restProviders = shouldShowGroup ? providers.slice(topGroupSize) : providers
+  // The collapsed-group row is rendered whenever a group exists, regardless of
+  // expansion state — clicking it toggles between showing the top-N as a
+  // single summary (collapsed) and listing them as individual rows below it
+  // with a decentralization bar between top-N and rest (expanded). Without
+  // this, the row vanishes on expand and the user has no way to fold it back.
+  const hasGroup = topGroupSize > 0 && providers.length > topGroupSize
+  const groupProviders = hasGroup ? providers.slice(0, topGroupSize) : []
+  const restProviders = hasGroup ? providers.slice(topGroupSize) : providers
   const shouldShowInlineBar =
-    !shouldShowGroup &&
+    !hasGroup &&
     showDecentralizationBar &&
     decentralizationBarAfterCount > 0 &&
     providers.length > decentralizationBarAfterCount
@@ -383,12 +388,12 @@ export const ProviderTable = ({
         ) : providers.length > 0 ? (
           <>
             {/* ── Top-group row ── */}
-            {shouldShowGroup && (
+            {hasGroup && (
               <>
                 {/* Collapsed / expanded toggle row */}
                 <TableRow
                   className="cursor-pointer select-none"
-                  onClick={() => setIsGroupExpanded(true)}
+                  onClick={() => setIsGroupExpanded((prev) => !prev)}
                 >
                   <TableCell>
                     <div className="flex items-center gap-3">
@@ -425,7 +430,7 @@ export const ProviderTable = ({
                       <Icon
                         name="chevronDown"
                         size="md"
-                        className="text-parchment/50"
+                        className={`text-parchment/50 transition-transform ${isGroupExpanded ? 'rotate-180' : ''}`}
                       />
                     </div>
                   </TableCell>
@@ -488,13 +493,35 @@ export const ProviderTable = ({
               </>
             )}
 
-            {/* Decentralization separator */}
-            {showDecentralizationBar && !shouldShowInlineBar && (
-              <DecentralizationBarRow />
-            )}
+            {/* Rendering matrix:
+                  - Group + collapsed: group row, decentralization bar, rest
+                  - Group + expanded:  group row, top-N individuals, decentralization bar, rest
+                  - No group, inline bar enabled: top-N individuals, bar, rest
+                  - No group, no bar: all individuals
+                The group row itself is rendered above this block. */}
+            {hasGroup ? (
+              <>
+                {isGroupExpanded && groupProviders.map((provider) => (
+                  <ProviderRow
+                    key={provider.id}
+                    provider={provider}
+                    config={providerConfigurations?.get(Number(provider.id))}
+                    {...sharedRowProps}
+                  />
+                ))}
 
-            {/* Individual provider rows (providers after the group, or all if no group) */}
-            {shouldShowInlineBar ? (
+                {showDecentralizationBar && <DecentralizationBarRow />}
+
+                {restProviders.map((provider) => (
+                  <ProviderRow
+                    key={provider.id}
+                    provider={provider}
+                    config={providerConfigurations?.get(Number(provider.id))}
+                    {...sharedRowProps}
+                  />
+                ))}
+              </>
+            ) : shouldShowInlineBar ? (
               <>
                 {inlineTopProviders.map((provider) => (
                   <ProviderRow

--- a/staking-dashboard/src/hooks/providers/useProviderTable.ts
+++ b/staking-dashboard/src/hooks/providers/useProviderTable.ts
@@ -36,6 +36,13 @@ export type SortField = 'name' | 'totalStaked' | 'commission'
 export type SortDirection = 'asc' | 'desc'
 
 /**
+ * Number of top providers that get collapsed into a single "group" row on
+ * page 1 (default sort, no search). Shared with `useProviderTableDisplayData`
+ * so pagination math and the display flag agree.
+ */
+export const TOP_GROUP_SIZE = 5
+
+/**
  * Fetch providers from API
  */
 async function fetchProviders(): Promise<ProvidersResponse> {
@@ -203,14 +210,42 @@ export const useProviderTable = () => {
       })
   }, [allProviders, searchQuery, sortField, sortDirection])
 
+  // Page 1 absorbs the grouped providers so the visible row count matches
+  // every other page. Collapsed view = 1 group row + (itemsPerPage - 1)
+  // individual rows = `itemsPerPage` slots, the same as page 2+. The first
+  // `TOP_GROUP_SIZE` providers collapse into the group row; the remaining
+  // `itemsPerPage - 1` render below. The gating below mirrors
+  // `useProviderTableDisplayData`'s `topGroupSize` derivation so the two stay
+  // in sync.
+  const showsTopGroupOnPage1 =
+    sortField === 'totalStaked' &&
+    sortDirection === 'desc' &&
+    !searchQuery &&
+    !hasUserSorted &&
+    filteredAndSortedProviders.length > TOP_GROUP_SIZE
+
+  const page1Size = showsTopGroupOnPage1
+    ? TOP_GROUP_SIZE + (itemsPerPage - 1)
+    : itemsPerPage
+
   const paginationData = useMemo(() => {
-    const totalPages = Math.ceil(filteredAndSortedProviders.length / itemsPerPage)
-    const startIndex = (currentPage - 1) * itemsPerPage
-    const endIndex = startIndex + itemsPerPage
+    const total = filteredAndSortedProviders.length
+    let startIndex: number
+    let endIndex: number
+    if (currentPage === 1) {
+      startIndex = 0
+      endIndex = Math.min(total, page1Size)
+    } else {
+      startIndex = page1Size + (currentPage - 2) * itemsPerPage
+      endIndex = Math.min(total, startIndex + itemsPerPage)
+    }
     const providers = filteredAndSortedProviders.slice(startIndex, endIndex)
+    const totalPages = total <= page1Size
+      ? Math.max(1, Math.ceil(total / itemsPerPage))
+      : 1 + Math.ceil((total - page1Size) / itemsPerPage)
 
     return { totalPages, startIndex, endIndex, providers }
-  }, [filteredAndSortedProviders, currentPage])
+  }, [filteredAndSortedProviders, currentPage, page1Size])
 
   const handleSearchChange = (query: string) => {
     setSearchQuery(query)

--- a/staking-dashboard/src/hooks/providers/useProviderTableDisplayData.ts
+++ b/staking-dashboard/src/hooks/providers/useProviderTableDisplayData.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 import { useAggregatedStakingData } from "@/hooks/atp/useAggregatedStakingData"
 import { useMultipleProviderQueueLengths, useMultipleProviderConfigurations } from "@/hooks/stakingRegistry"
-import { type ProviderListItem, type SortDirection, type SortField } from "@/hooks/providers/useProviderTable"
+import { TOP_GROUP_SIZE, type ProviderListItem, type SortDirection, type SortField } from "@/hooks/providers/useProviderTable"
 
 interface UseProviderTableDisplayDataParams {
   providers: ProviderListItem[]
@@ -11,8 +11,6 @@ interface UseProviderTableDisplayDataParams {
   searchQuery: string
   hasUserSorted: boolean
 }
-
-const TOP_GROUP_SIZE = 5
 
 /**
  * Shared display data for provider table entry points.


### PR DESCRIPTION
Two fixes to the providers table:

- Page 1 was showing only 5 individual providers below the "Top 5" group row (because pagination still served 10 raw providers, the first 5 of which got collapsed). Pagination now serves 14 on page 1, the first 5 collapse into the group row and 9 render individually, so the visible row count matches every other page (10 slots).
- The "Top 5" group row could be expanded but not collapsed back. The row now stays rendered in both states, click toggles, the chevron rotates, and the top-5 individual rows appear below it with the decentralisation bar between top and rest.

`TOP_GROUP_SIZE` is now exported from `useProviderTable` and reused by `useProviderTableDisplayData` so the pagination math and the display flag can't drift.