### PR TITLE
fix: restore partial-claim recovery for stranded split balance

### DIFF
--- a/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsModal.tsx
+++ b/staking-dashboard/src/components/ATPDetailsModal/ATPDetailsModal.tsx
@@ -435,6 +435,7 @@ export const ATPDetailsModal = ({ atp, isOpen, onClose, onWithdrawSuccess, onRef
                         providerRewardsRecipient: d.providerRewardsRecipient as Address,
                         rewards: rewards?.userRewards ?? 0n,
                         rollupRewardsByRollup: rewards?.rollupRewardsByRollup,
+                        splitContractBalance: rewards?.splitContractBalance,
                         providerName: d.providerName,
                         providerId: d.providerId,
                       }

--- a/staking-dashboard/src/components/ATPStakingOverview/ATPStakingOverviewBreakdownSection.tsx
+++ b/staking-dashboard/src/components/ATPStakingOverview/ATPStakingOverviewBreakdownSection.tsx
@@ -230,6 +230,7 @@ export const ATPStakingOverviewBreakdownSection = ({
                       providerRewardsRecipient: d.providerRewardsRecipient as `0x${string}`,
                       rewards: d.rewards,
                       rollupRewardsByRollup: d.rollupRewardsByRollup,
+                      splitContractBalance: d.splitContractBalance,
                       providerName: d.providerName,
                       providerId: d.providerId,
                     })),
@@ -239,6 +240,7 @@ export const ATPStakingOverviewBreakdownSection = ({
                       providerRewardsRecipient: d.providerRewardsRecipient as `0x${string}`,
                       rewards: d.rewards,
                       rollupRewardsByRollup: d.rollupRewardsByRollup,
+                      splitContractBalance: d.splitContractBalance,
                       providerName: d.providerName,
                       providerId: d.providerId,
                     }))

--- a/staking-dashboard/src/components/ClaimAllDelegationRewardsButton/ClaimAllDelegationRewardsButton.tsx
+++ b/staking-dashboard/src/components/ClaimAllDelegationRewardsButton/ClaimAllDelegationRewardsButton.tsx
@@ -23,6 +23,10 @@ interface DelegationClaim {
   rewards: bigint
   /** Required for the helper to fan out per-rollup claims. */
   rollupRewardsByRollup?: Array<{ rollupAddress: Address; rollupVersion: string; rewards: bigint }>
+  /** Tokens already on the split contract awaiting distribute. Needed so a
+   *  partially-executed claim (claim ran, distribute didn't) can still be
+   *  recovered as a distribute-only entry. */
+  splitContractBalance?: bigint
   providerName?: string | null
   providerId?: number
 }
@@ -52,12 +56,15 @@ export const ClaimAllDelegationRewardsButton = ({
   const firstSplit = delegations[0]?.splitContract
   const { warehouseAddress } = useSplitsWarehouse(firstSplit)
 
-  // Filter to delegations that have *anything* claimable — canonical or stranded.
+  // Filter to delegations that have *anything* claimable — canonical, stranded
+  // on a non-canonical rollup, or already swept into the split contract but
+  // awaiting distribute.
   const claimableDelegations = useMemo(() => {
     const canonicalRollup = contracts.rollup.address.toLowerCase()
     return delegations.filter((d) => {
       const perRollup = d.rollupRewardsByRollup ?? []
       return perRollup.some((r) => r.rewards > 0n)
+        || (d.splitContractBalance ?? 0n) > 0n
         || (d.rewards > 0n && !perRollup.some((r) => r.rollupAddress.toLowerCase() === canonicalRollup))
     })
   }, [delegations])
@@ -93,6 +100,7 @@ export const ClaimAllDelegationRewardsButton = ({
         tokenAddress,
         decimals: decimals ?? 18,
         symbol: symbol ?? "",
+        splitContractBalance: d.splitContractBalance,
       })
       entries.push(...delegationEntries)
       if (distributeGroup) lastDistributeGroup = distributeGroup

--- a/staking-dashboard/src/components/ClaimAllRewardsModal/ClaimAllRewardsModal.tsx
+++ b/staking-dashboard/src/components/ClaimAllRewardsModal/ClaimAllRewardsModal.tsx
@@ -73,6 +73,7 @@ export const ClaimAllRewardsModal = ({
         tokenAddress,
         decimals: decimals ?? 18,
         symbol: symbol ?? "",
+        splitContractBalance: d.splitContractBalance,
       })
       entriesToAdd.push(...entries)
       if (distributeGroup) lastDistributeGroup = distributeGroup

--- a/staking-dashboard/src/components/ClaimDelegationRewardsButton/ClaimDelegationRewardsButton.tsx
+++ b/staking-dashboard/src/components/ClaimDelegationRewardsButton/ClaimDelegationRewardsButton.tsx
@@ -89,6 +89,7 @@ export const ClaimDelegationRewardsButton = ({
       tokenAddress,
       decimals: decimals ?? 18,
       symbol: symbol ?? "",
+      splitContractBalance: currentSplitBalance,
     })
     const withdraw = entries.length > 0 || currentWarehouseBalance > 0n
       ? buildWarehouseWithdrawEntry({

--- a/staking-dashboard/src/components/WalletStakesDetailsModal/WalletStakesDetailsModal.tsx
+++ b/staking-dashboard/src/components/WalletStakesDetailsModal/WalletStakesDetailsModal.tsx
@@ -170,6 +170,7 @@ export const WalletStakesDetailsModal = ({
                         providerRewardsRecipient: d.providerRewardsRecipient,
                         rewards: d.rewards,
                         rollupRewardsByRollup: d.rollupRewardsByRollup,
+                        splitContractBalance: d.splitContractBalance,
                         providerName: d.providerName,
                         providerId: d.providerId,
                       }))}

--- a/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
+++ b/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
@@ -58,6 +58,10 @@ export interface DelegationBreakdown {
   /** Per-rollup unclaimed `getSequencerRewards(splitContract)` balances. Used by the
    *  claim engine to pre-sweep stranded balances from non-canonical rollups. */
   rollupRewardsByRollup: Array<{ rollupAddress: Address; rollupVersion: string; rewards: bigint }>
+  /** ERC20 balance currently sitting on the split contract. Non-zero means a
+   *  previous claim landed tokens here but distribute hasn't run yet — the
+   *  claim engine needs this to surface a distribute-only recovery flow. */
+  splitContractBalance: bigint
 }
 
 export interface Erc20DelegationBreakdown {
@@ -81,6 +85,8 @@ export interface Erc20DelegationBreakdown {
   /** Per-rollup unclaimed `getSequencerRewards(splitContract)` balances. Used by the
    *  claim engine to pre-sweep stranded balances from non-canonical rollups. */
   rollupRewardsByRollup: Array<{ rollupAddress: Address; rollupVersion: string; rewards: bigint }>
+  /** See {@link DelegationBreakdown.splitContractBalance}. */
+  splitContractBalance: bigint
 }
 
 export interface Erc20DirectStakeBreakdown {
@@ -321,6 +327,7 @@ function parseDelegation(
     timestamp: delegation.timestamp,
     blockNumber: delegation.blockNumber,
     rollupRewardsByRollup: rollupBalancesByRollup,
+    splitContractBalance,
   }
 }
 
@@ -390,6 +397,7 @@ function parseErc20Delegation(
     timestamp: delegation.timestamp,
     blockNumber: delegation.blockNumber,
     rollupRewardsByRollup: rollupBalancesByRollup,
+    splitContractBalance,
   }
 }
 

--- a/staking-dashboard/src/hooks/staker/types.ts
+++ b/staking-dashboard/src/hooks/staker/types.ts
@@ -12,6 +12,11 @@ export interface StakeWithProviderReward {
     rollupVersion: string
     rewards: bigint
   }>
+  /** ERC20 balance currently sitting on the split contract. Non-zero with no
+   *  per-rollup balance means a prior claim landed tokens here but distribute
+   *  hasn't run yet — the claim engine needs this to surface a distribute-only
+   *  recovery flow. */
+  splitContractBalance: bigint
 }
 
 export interface G1Point {

--- a/staking-dashboard/src/hooks/staker/useMultipleStakeWithProviderRewards.ts
+++ b/staking-dashboard/src/hooks/staker/useMultipleStakeWithProviderRewards.ts
@@ -102,6 +102,7 @@ export const useMultipleStakeWithProviderRewards = ({
       userRewards,
       takeRate: delegation.providerTakeRate,
       rollupRewardsByRollup,
+      splitContractBalance: splitBalance,
     }
   })
 

--- a/staking-dashboard/src/utils/claimCart.ts
+++ b/staking-dashboard/src/utils/claimCart.ts
@@ -53,6 +53,11 @@ export interface DelegationClaimInputs {
   tokenAddress: Address
   decimals: number
   symbol: string
+  /** Current ERC20 balance sitting on the split contract — i.e. tokens already
+   *  claimed from a rollup but not yet distributed. When this is non-zero and
+   *  no per-rollup balances need claiming, the helper emits a distribute-only
+   *  plan so a previously stranded balance can still be swept to the user. */
+  splitContractBalance?: bigint
 }
 
 export interface DelegationClaimResult {
@@ -81,10 +86,15 @@ export function buildDelegationClaimEntries(inputs: DelegationClaimInputs): Dele
     tokenAddress,
     decimals,
     symbol,
+    splitContractBalance = 0n,
   } = inputs
 
   const claimables = rollupRewardsByRollup.filter((r) => r.rewards > 0n)
-  if (claimables.length === 0) {
+  // Distribute-only recovery: no rollup balance to claim, but the split
+  // contract still holds tokens from a prior partially-executed claim. Emit
+  // just the distribute (no claim deps) so the user can sweep the stranded
+  // balance. Without this branch the button/modal becomes a silent no-op.
+  if (claimables.length === 0 && splitContractBalance === 0n) {
     return { entries: [], distributeGroup: null }
   }
 


### PR DESCRIPTION
## The bug

After a partially-completed claim — where `claim` ran (tokens moved from the rollup to the split contract) but `distribute` never ran — the user's rewards sit stuck on the split contract. The UI showed those rewards as claimable and the **Claim** button was enabled, but clicking it did nothing: no transaction, no error. The user had no way to recover their funds from the UI.

Root cause: `buildDelegationClaimEntries` returned an empty plan whenever no rollup had a positive balance, ignoring that the split contract still held tokens awaiting `distribute`.

## Why this is a real problem (not an exotic edge case)

The state arises any time the multi-step flow is interrupted between claim and distribute:

- User confirms the claim tx, then closes the cart / wallet / tab before signing distribute.
- The distribute tx reverts (gas, slippage, race) while the claim is already on-chain.
- User claimed previously via Etherscan or an older app version that didn't auto-distribute.

The previous hook (`useClaimSplitRewards`) explicitly supported this recovery — it would skip the zero-balance claim and proceed straight to distribute. The new cart flow lost that path, leaving any user in this state with a silent dead button.

## Fix

Thread `splitContractBalance` into `buildDelegationClaimEntries`. When `claimables.length === 0` but `splitContractBalance > 0n`, the helper now emits a distribute-only entry (no claim deps), and the existing warehouse-withdraw wiring chains onto it so the stranded balance gets swept to the user.

The new field is plumbed through:

- `claimCart.ts` — added `splitContractBalance` input + distribute-only branch.
- `useAggregatedStakingData.ts` — exposed `splitContractBalance` on `DelegationBreakdown` / `Erc20DelegationBreakdown` (it was already fetched on-chain, just dropped before).
- `staker/types.ts` + `useMultipleStakeWithProviderRewards.ts` — exposed `splitContractBalance` on `StakeWithProviderReward`.
- `ClaimDelegationRewardsButton`, `ClaimAllDelegationRewardsButton` (incl. the `claimableDelegations` filter), and `ClaimAllRewardsModal` — forward the value to the helper.
- The three call sites that supply delegations to `ClaimAllDelegationRewardsButton` (`ATPStakingOverviewBreakdownSection`, `WalletStakesDetailsModal`, `ATPDetailsModal`) — pass the new field through.
