### PR TITLE
fix: don't claim success when a multicall batch fails before sending

### DIFF
--- a/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
+++ b/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
@@ -448,6 +448,7 @@ export function useMulticall3Execution({
     allTransactions: CartTransaction[],
   ): Promise<void> => {
     if (!walletClient || !publicClient) {
+      showAlert('error', 'Wallet client not ready')
       throw new Error('Wallet client not ready')
     }
 
@@ -468,6 +469,7 @@ export function useMulticall3Execution({
 
     const hasExecutingTx = allTransactions.some((tx) => tx.status === 'executing' && tx.txHash)
     if (hasExecutingTx) {
+      showAlert('info', 'Please wait for the current transaction to complete')
       throw new Error('Please wait for the current transaction to complete')
     }
 

--- a/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
+++ b/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
@@ -448,7 +448,9 @@ export function useMulticall3Execution({
     allTransactions: CartTransaction[],
   ): Promise<void> => {
     if (!walletClient || !publicClient) {
-      showAlert('error', 'Wallet client not ready')
+      // Don't `showAlert` here — `TransactionCartContext.executeAll` wraps
+      // this in a try/catch and emits the toast from `error.message`.
+      // Calling showAlert too would double-render the same toast.
       throw new Error('Wallet client not ready')
     }
 
@@ -469,7 +471,7 @@ export function useMulticall3Execution({
 
     const hasExecutingTx = allTransactions.some((tx) => tx.status === 'executing' && tx.txHash)
     if (hasExecutingTx) {
-      showAlert('info', 'Please wait for the current transaction to complete')
+      // See note above: outer wrapper emits the toast from `error.message`.
       throw new Error('Please wait for the current transaction to complete')
     }
 
@@ -515,12 +517,14 @@ export function useMulticall3Execution({
       if (!sim.ok) {
         const reason = `Batch simulation failed${chunkLabel}: ${sim.reason}`
         const friendlyReason = parseContractError(sim.reason)
+        // Mark every entry in the chunk failed so the cart panel shows
+        // per-entry attribution. The user-facing toast is emitted by the
+        // outer `TransactionCartContext.executeAll` catch from `error.message`.
         setTransactions((prev) => prev.map((t) =>
           chunk.some((p) => p.id === t.id)
             ? { ...t, status: 'failed' as TransactionStatus, error: friendlyReason }
             : t,
         ))
-        showAlert('error', reason)
         throw new Error(reason)
       }
 
@@ -529,12 +533,13 @@ export function useMulticall3Execution({
       const outcome = verifyOutcome(sim.returnData, chunk.length)
       if (!outcome.ok) {
         const reason = `Batch outcome check failed${chunkLabel}: ${outcome.reason}`
+        // See note in 3a: toast comes from the outer wrapper; this block
+        // only adds per-entry failure attribution.
         setTransactions((prev) => prev.map((t) =>
           chunk.some((p) => p.id === t.id)
             ? { ...t, status: 'failed' as TransactionStatus, error: outcome.reason }
             : t,
         ))
-        showAlert('error', reason)
         throw new Error(reason)
       }
 

--- a/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
+++ b/staking-dashboard/src/hooks/transactionCart/useMulticall3Execution.ts
@@ -448,8 +448,7 @@ export function useMulticall3Execution({
     allTransactions: CartTransaction[],
   ): Promise<void> => {
     if (!walletClient || !publicClient) {
-      showAlert('error', 'Wallet client not ready')
-      return
+      throw new Error('Wallet client not ready')
     }
 
     // `walletClient.account` can transiently be undefined between connect
@@ -469,8 +468,7 @@ export function useMulticall3Execution({
 
     const hasExecutingTx = allTransactions.some((tx) => tx.status === 'executing' && tx.txHash)
     if (hasExecutingTx) {
-      showAlert('info', 'Please wait for the current transaction to complete')
-      return
+      throw new Error('Please wait for the current transaction to complete')
     }
 
     // Belt-and-braces guard. The dispatcher already checks eligibility — re-check here
@@ -507,17 +505,35 @@ export function useMulticall3Execution({
       const chunkLabel = chunks.length > 1 ? ` (${i + 1}/${chunks.length})` : ''
 
       // 3a. Simulate this chunk against the latest state (post-previous-chunk if any).
+      // On failure, mark every entry in the chunk `failed` with the reason and
+      // throw so the dispatcher (`runSegment` → `executeAll`) aborts. Returning
+      // silently here would let `executeAll` continue to subsequent segments
+      // and fire its terminal success toast — masking the simulation failure.
       const sim = await simulateBatch(chunk)
       if (!sim.ok) {
-        showAlert('error', `Batch simulation failed${chunkLabel}: ${sim.reason}`)
-        return
+        const reason = `Batch simulation failed${chunkLabel}: ${sim.reason}`
+        const friendlyReason = parseContractError(sim.reason)
+        setTransactions((prev) => prev.map((t) =>
+          chunk.some((p) => p.id === t.id)
+            ? { ...t, status: 'failed' as TransactionStatus, error: friendlyReason }
+            : t,
+        ))
+        showAlert('error', reason)
+        throw new Error(reason)
       }
 
       // 3b. Structural outcome verification — every inner success flag true.
+      // Same throw-not-return rationale as 3a above.
       const outcome = verifyOutcome(sim.returnData, chunk.length)
       if (!outcome.ok) {
-        showAlert('error', `Batch outcome check failed${chunkLabel}: ${outcome.reason}`)
-        return
+        const reason = `Batch outcome check failed${chunkLabel}: ${outcome.reason}`
+        setTransactions((prev) => prev.map((t) =>
+          chunk.some((p) => p.id === t.id)
+            ? { ...t, status: 'failed' as TransactionStatus, error: outcome.reason }
+            : t,
+        ))
+        showAlert('error', reason)
+        throw new Error(reason)
       }
 
       // 3c. Mark chunk entries `executing` (untouched downstream chunks stay pending).


### PR DESCRIPTION
## What this fixes

When you click Execute on a multicall batch, the app runs a dry-run on the blockchain first to catch failures before they cost a signature. The dry-run was correctly detecting failures — but then exiting silently. The dispatcher above didn't realise anything was wrong and, a second later, fired a green **"All transactions executed successfully"** toast.

So on a real failure the user saw: red error → green success, with no on-chain transaction behind it. They could easily believe their action succeeded, walk away, and only later notice nothing happened. This isn't rare — it's exactly the "balance changed / someone else already claimed / admin updated something" condition the dry-run is there to catch.

## The change

Four pre-flight bail points in the multicall path now throw instead of returning silently, so the dispatcher correctly aborts and the success toast doesn't fire. For the two failures that happen after the cart already accepted the batch (dry-run revert, outcome mismatch), every entry in the affected chunk is also marked **failed** in the cart panel so the user sees which entries didn't go through.

No new behaviour, no new dependencies, no UI changes beyond clearer failure attribution.