### PR TITLE
atp-indexer: single-instance stack (collapse ECS+Aurora+ALB onto one box) + API performance fixes

### DIFF
--- a/.github/workflows/deploy-indexer.yaml
+++ b/.github/workflows/deploy-indexer.yaml
@@ -17,10 +17,20 @@ on:
         default: false
         type: boolean
       green:
-        description: "Whether to deploy green instance"
+        description: "Whether to deploy green instance (fleet only)"
         required: false
         default: false
         type: boolean
+      single_instance:
+        description: "Deploy to the single-instance box (default) instead of the ECS fleet"
+        required: false
+        default: true
+        type: boolean
+      new_schema:
+        description: "Single-instance: new DATABASE_SCHEMA for indexing-code changes (A/B rebuild + flip); leave empty for metadata-only updates"
+        required: false
+        default: ""
+        type: string
 
   push:
     tags:
@@ -35,7 +45,59 @@ permissions:
   actions: read
 
 jobs:
+  deploy-single-instance:
+    if: ${{ inputs.single_instance != false }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
+    env:
+      ENV: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: atp-indexer/yarn.lock
+
+      - name: Configure AWS credentials with GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Build image (providers.json is generated pre-build; the Dockerfile enforces it)
+        working-directory: atp-indexer
+        run: |
+          yarn install --frozen-lockfile
+          yarn bootstrap
+          aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
+          IMAGE="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/atp-indexer-$ENV-atp-indexer:si-${GITHUB_SHA::7}"
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to the box via SSM (box-deploy.sh handles same-app vs A/B schema flip)
+        run: |
+          set -euo pipefail
+          IID=$(aws ec2 describe-instances             --filters "Name=tag:Name,Values=staking-dashboard-atp-single-instance-$ENV" "Name=instance-state-name,Values=running"             --query 'Reservations[0].Instances[0].InstanceId' --output text)
+          [ "$IID" != "None" ] || { echo "no running box for env $ENV"; exit 1; }
+          SCRIPT_B64=$(base64 -w0 atp-indexer/single-instance/scripts/box-deploy.sh)
+          CMD_ID=$(aws ssm send-command --instance-ids "$IID" --document-name AWS-RunShellScript             --timeout-seconds 3600             --parameters "$(jq -nc --arg b "$SCRIPT_B64" --arg img "$IMAGE" --arg schema "${{ inputs.new_schema }}"               '{commands: [("echo "+$b+" | base64 -d > /opt/staking-dashboard-atp/box-deploy.sh"), "chmod +x /opt/staking-dashboard-atp/box-deploy.sh", ("/opt/staking-dashboard-atp/box-deploy.sh "+$img+" "+$schema)], executionTimeout: ["3600"]}')"             --query 'Command.CommandId' --output text)
+          echo "SSM command: $CMD_ID"
+          while :; do
+            ST=$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query Status --output text)
+            case "$ST" in Success) break;; Failed|Cancelled|TimedOut) aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query '{out:StandardOutputContent,err:StandardErrorContent}' --output text; exit 1;; esac
+            sleep 15
+          done
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query StandardOutputContent --output text
+
   deploy:
+    if: ${{ inputs.single_instance == false }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
     env:

--- a/atp-indexer/Dockerfile
+++ b/atp-indexer/Dockerfile
@@ -11,6 +11,11 @@ RUN yarn install --frozen-lockfile
 # Copy source code (includes pre-generated providers.json)
 COPY . .
 
+# providers.json is generated from the repo-root providers/ dir by `yarn bootstrap` and must
+# exist before the image is built (CI does this; local builds must too). Without it the
+# /api/providers response silently loses all provider metadata.
+RUN test -s src/api/data/providers.json || (echo "ERROR: src/api/data/providers.json missing or empty — run 'yarn bootstrap' before building" && exit 1)
+
 # Generate Ponder types
 RUN yarn codegen
 

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -30,8 +30,11 @@ terraform apply \
   -var si_atp_indexer_domain=indexer.testnet.stake.aztec.network
 ```
 Then SSM onto the box, populate `/opt/staking-dashboard-atp/env/atp-indexer.env` with the
-same values the ECS task-def used (RPC_URL, CHAIN_ID, START_BLOCK, the `ATP_FACTORY_*` /
-`*_START_BLOCK` / registry vars — see `atp-indexer/terraform/app.tf`), then
+**same values the ECS task-def used** — copy the full set from `atp-indexer/terraform/app.tf`
+(`indexer_env_vars`, ~25 vars). The required ones are RPC_URL, CHAIN_ID, START_BLOCK, the
+`ATP_FACTORY_*` addresses, `*_FACTORY_START_BLOCK`, and the registry vars; the rest are tuning
+(`BLOCK_BATCH_SIZE`, `POLLING_INTERVAL`, `MAX_RETRIES`, `PARALLEL_BATCHES`, `CLEANUP_*`,
+`TRUST_PROXY`, `PONDER_TELEMETRY_DISABLED`) and fall back to image defaults if omitted. Then
 `docker compose up -d` (or set `-var si_start_services_on_boot=true` once the env file exists).
 
 ### testnet (Caddy-direct)
@@ -47,11 +50,16 @@ CloudFront serves viewer TLS; the box serves http-only to CloudFront only.
 ## Cutover (decommission the old fleet)
 1. Stand up this box; seed/let it reach head (the indexer is RPC-bound — see ignition's
    ROAD-TO-PROD notes; restore a `pg_dump` if you have one to skip the reindex).
-2. Repoint the **frontend's** indexer URL to this box's endpoint:
-   - testnet: the hostname now resolves to the EIP (Caddy-direct), or
-   - prod: `cloudfront_domain_name` output (or move the existing indexer hostname's alias here).
-   The frontend reads the atp-indexer's URL from remote state today
-   (`staking-dashboard/terraform` → `atp_indexer_url`); update that source at cutover.
+2. Repoint the **frontend's** indexer URL to this box's endpoint. The frontend reads it from
+   the atp-indexer's remote state today (`staking-dashboard/terraform/data.tf` →
+   `data.terraform_remote_state.atp-indexer.outputs.cf_domain_name`). At cutover, change that
+   data source's `key` from the old atp-indexer state
+   (`.../backends/atp-indexer/terraform.tfstate`) to this stack's state
+   (`<env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate`). This stack
+   exposes a **`cf_domain_name`** output (same name as the old stack), so no frontend code
+   change beyond the state `key` is needed.
+   - testnet: alternatively the hostname resolves to the EIP directly (Caddy-direct).
+   - prod: the `cf_domain_name`/`cloudfront_domain_name` output is the box's CloudFront.
 3. After parity, tear down the old `atp-indexer/terraform` ECS service / Aurora / ALB
    (e.g. scale the service to 0, then `terraform destroy` those resources). **Snapshot the
    Aurora data first.** Keep the existing CloudFront if you prefer to repoint its origin

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -50,16 +50,22 @@ CloudFront serves viewer TLS; the box serves http-only to CloudFront only.
 ## Cutover (decommission the old fleet)
 1. Stand up this box; seed/let it reach head (the indexer is RPC-bound — see ignition's
    ROAD-TO-PROD notes; restore a `pg_dump` if you have one to skip the reindex).
-2. Repoint the **frontend's** indexer URL to this box's endpoint. The frontend reads it from
-   the atp-indexer's remote state today (`staking-dashboard/terraform/data.tf` →
-   `data.terraform_remote_state.atp-indexer.outputs.cf_domain_name`). At cutover, change that
-   data source's `key` from the old atp-indexer state
-   (`.../backends/atp-indexer/terraform.tfstate`) to this stack's state
-   (`<env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate`). This stack
-   exposes a **`cf_domain_name`** output (same name as the old stack), so no frontend code
-   change beyond the state `key` is needed.
-   - testnet: alternatively the hostname resolves to the EIP directly (Caddy-direct).
-   - prod: the `cf_domain_name`/`cloudfront_domain_name` output is the box's CloudFront.
+2. Repoint the **frontend's** indexer URL to this box's endpoint:
+   - **2a. Terraform state.** The frontend reads the URL from the atp-indexer's remote state
+     (`staking-dashboard/terraform/data.tf` →
+     `data.terraform_remote_state.atp-indexer.outputs.cf_domain_name`). Change that data
+     source's `key` from the old atp-indexer state (`.../backends/atp-indexer/terraform.tfstate`)
+     to this stack's state (`<env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate`).
+     This stack exposes a **`cf_domain_name`** output **in both modes** (same name as the old
+     stack), so no frontend code change beyond the state `key`:
+       - prod (CloudFront-front): `cf_domain_name` = the box's CloudFront domain.
+       - testnet (Caddy-direct): `cf_domain_name` = the indexer hostname (`si_atp_indexer_domain`,
+         which resolves to the EIP with Caddy serving Let's Encrypt TLS).
+   - **2b. Rebuild + redeploy the frontend.** The indexer URL is baked into the static build at
+     build time (`staking-dashboard/bootstrap.sh` reads `ATP_INDEXER_URL` from the terraform
+     output). So after 2a you must **rebuild and redeploy** the frontend to S3+CloudFront for it
+     to point at the new indexer — a terraform change alone is not enough. Do this only **after**
+     the box has reached parity, so the live frontend never points at an empty indexer.
 3. After parity, tear down the old `atp-indexer/terraform` ECS service / Aurora / ALB
    (e.g. scale the service to 0, then `terraform destroy` those resources). **Snapshot the
    Aurora data first.** Keep the existing CloudFront if you prefer to repoint its origin

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -43,8 +43,11 @@ at the EIP first).
 
 ### prod (CloudFront-front)
 `-var si_front_with_cloudfront=true -var si_create_dns_records=false`
-`-var cloudfront_secret_header_value=<secret>` (Caddy enforces it; CloudFront injects it)
-`-var si_cf_web_acl_arn=<cloudfront-scoped WAF arn>` (optional).
+The **CloudFront secret header** and **CLOUDFRONT-scoped WAF** are read automatically from the
+shared `ignition-infrastructure` state / SSM — the same ones the existing atp-indexer
+CloudFront uses — so you normally **don't** pass them. Set `-var env_parent=<parent>` if the
+shared state isn't under the same env name. Overrides if ever needed:
+`-var cloudfront_secret_header_value=<secret>`, `-var si_cf_web_acl_arn=<arn>`.
 CloudFront serves viewer TLS; the box serves http-only to CloudFront only.
 
 ## Cutover (decommission the old fleet)

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -19,6 +19,13 @@ moves the expensive indexer.
   (us-east-1), an http-only origin via a stable `atp-si-origin.<env>` A-record → EIP, and the
   CloudFront secret header that Caddy enforces.
 
+## Endpoint
+
+Hostname convention: **`api.<env>.stake.aztec.network`**, and **`api.stake.aztec.network`**
+for prod — one stable, branded API endpoint. The dashboard's `VITE_API_HOST` points at it
+instead of a raw `*.cloudfront.net` URL, so swapping the infra behind it (fleet → box, or
+anything later) never requires a frontend change again.
+
 ## Deploy
 ```sh
 cd atp-indexer/single-instance
@@ -27,7 +34,7 @@ terraform apply \
   -var env=testnet \
   -var si_atp_indexer_image=<account>.dkr.ecr.eu-west-2.amazonaws.com/staking-dashboard-testnet-atp-indexer:<tag> \
   -var si_atp_database_schema=atp_indexer \
-  -var si_atp_indexer_domain=indexer.testnet.stake.aztec.network
+  -var si_atp_indexer_domain=api.testnet.stake.aztec.network
 ```
 Then SSM onto the box, populate `/opt/staking-dashboard-atp/env/atp-indexer.env` with the
 **same values the ECS task-def used** — copy the full set from `atp-indexer/terraform/app.tf`

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -57,6 +57,25 @@ shared state isn't under the same env name. Overrides if ever needed:
 `-var cloudfront_secret_header_value=<secret>`, `-var si_cf_web_acl_arn=<arn>`.
 CloudFront serves viewer TLS; the box serves http-only to CloudFront only.
 
+## Deploys & resyncs (A/B on the box)
+
+The fleet used a whole second environment (prod-g) so a resync could run against a non-live
+backend. The box gets the same property from Ponder's schema-per-deploy model, one tier down:
+
+1. **Code deploy / resync (common case)** — run the new build as a second compose service
+   (`atp-indexer-next`, its own `DATABASE_SCHEMA`, internal port) against the same local
+   Postgres. It rebuilds its schema from the shared `ponder_sync` RPC cache (~2 min, zero
+   RPC refetch; a true from-chain resync also works and only that container pays for it)
+   while the live container keeps serving. Verify parity (row counts, spot queries), then
+   flip Caddy's `reverse_proxy` target (or swap the service image) — instant, no CloudFront
+   change. The old schema stays in Postgres as the instant rollback.
+2. **Box-level A/B (risky changes: OS, volume, Postgres major)** — the stack is additive, so
+   stand up a second box and repoint the `si-origin` A-record (60s TTL) at the new EIP.
+   CloudFront and the public hostname never change.
+
+Metadata-only image updates (providers.json) don't change the Ponder build fingerprint:
+pull + restart adopts the existing schema and is back at head in seconds.
+
 ## Cutover (decommission the old fleet)
 1. Stand up this box; seed/let it reach head (the indexer is RPC-bound — see ignition's
    ROAD-TO-PROD notes; restore a `pg_dump` if you have one to skip the reindex).

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -1,0 +1,63 @@
+# atp-indexer single-instance stack
+
+Collapses the staking-dashboard **atp-indexer**'s per-env **ECS + Aurora + ALB** onto one
+EC2 box running the indexer (this repo's own image) against a **local Postgres**, fronted by
+**Caddy** (Caddy-direct TLS for testnet, or **CloudFront-front** for prod). This mirrors the
+ignition-monorepo single-instance pattern — the two repos are decoupled and their
+atp-indexers have **diverged** (this one additionally indexes `ATP_FACTORY_MATP`/`LATP` and
+has the zombie/withdrawing provider features), so each repo runs **its own** indexer code.
+
+The **frontend is unchanged** — it stays on S3+CloudFront (already ~free). This stack only
+moves the expensive indexer.
+
+## What it creates (own Terraform state)
+- EC2 (default-VPC public subnet) + EIP + a persistent gp3 `/data` EBS volume (xfs).
+- IAM (SSM core + ECR pull), a public 80/443 security group.
+- `user_data` that mounts `/data`, writes `docker-compose.yml` + `Caddyfile`, and (optionally)
+  `docker compose up`. Services: `atp-indexer` (port 42068), `local-postgres` (16), `caddy`.
+- Optionally (prod) a CloudFront distribution fronting the indexer hostname with ACM
+  (us-east-1), an http-only origin via a stable `atp-si-origin.<env>` A-record → EIP, and the
+  CloudFront secret header that Caddy enforces.
+
+## Deploy
+```sh
+cd atp-indexer/single-instance
+terraform init -backend-config="key=<env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate"
+terraform apply \
+  -var env=testnet \
+  -var si_atp_indexer_image=<account>.dkr.ecr.eu-west-2.amazonaws.com/staking-dashboard-testnet-atp-indexer:<tag> \
+  -var si_atp_database_schema=atp_indexer \
+  -var si_atp_indexer_domain=indexer.testnet.stake.aztec.network
+```
+Then SSM onto the box, populate `/opt/staking-dashboard-atp/env/atp-indexer.env` with the
+same values the ECS task-def used (RPC_URL, CHAIN_ID, START_BLOCK, the `ATP_FACTORY_*` /
+`*_START_BLOCK` / registry vars — see `atp-indexer/terraform/app.tf`), then
+`docker compose up -d` (or set `-var si_start_services_on_boot=true` once the env file exists).
+
+### testnet (Caddy-direct)
+`-var si_create_dns_records=true` → Caddy gets Let's Encrypt certs for the hostname (point DNS
+at the EIP first).
+
+### prod (CloudFront-front)
+`-var si_front_with_cloudfront=true -var si_create_dns_records=false`
+`-var cloudfront_secret_header_value=<secret>` (Caddy enforces it; CloudFront injects it)
+`-var si_cf_web_acl_arn=<cloudfront-scoped WAF arn>` (optional).
+CloudFront serves viewer TLS; the box serves http-only to CloudFront only.
+
+## Cutover (decommission the old fleet)
+1. Stand up this box; seed/let it reach head (the indexer is RPC-bound — see ignition's
+   ROAD-TO-PROD notes; restore a `pg_dump` if you have one to skip the reindex).
+2. Repoint the **frontend's** indexer URL to this box's endpoint:
+   - testnet: the hostname now resolves to the EIP (Caddy-direct), or
+   - prod: `cloudfront_domain_name` output (or move the existing indexer hostname's alias here).
+   The frontend reads the atp-indexer's URL from remote state today
+   (`staking-dashboard/terraform` → `atp_indexer_url`); update that source at cutover.
+3. After parity, tear down the old `atp-indexer/terraform` ECS service / Aurora / ALB
+   (e.g. scale the service to 0, then `terraform destroy` those resources). **Snapshot the
+   Aurora data first.** Keep the existing CloudFront if you prefer to repoint its origin
+   instead of using this stack's CloudFront — either works; pick one to own the hostname.
+
+## Notes
+- Intentional duplication of the ignition single-instance templates (the repos are decoupled).
+- `terraform validate` passes. Not yet applied; prod is a separate account — review + `plan`
+  there before applying.

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -26,6 +26,25 @@ for prod — one stable, branded API endpoint. The dashboard's `VITE_API_HOST` p
 instead of a raw `*.cloudfront.net` URL, so swapping the infra behind it (fleet → box, or
 anything later) never requires a frontend change again.
 
+## Pre-flight (new box standups)
+
+- **EIP headroom**: the stack allocates one Elastic IP; `AddressLimitExceeded` has bitten two
+  standups. Check `aws ec2 describe-addresses` against the account quota first (an increase
+  to 30 was requested).
+- **Runtime env**: put the 21-var env in SSM as a SecureString at
+  `/staking-dashboard-atp/<env>/atp-indexer.env` (same values the deploy workflow holds as
+  GitHub environment vars). The box fetches it at boot via `fetch-env.sh`; it never starts on
+  an unpopulated env file.
+- **Image**: build with `yarn bootstrap` run first — the Dockerfile refuses to build without
+  the generated `providers.json`.
+
+## Deploys
+
+Use the **Deploy ATP Indexer** workflow (single-instance is the default): it builds + pushes
+the image and invokes `scripts/box-deploy.sh` on the box via SSM. Metadata-only changes
+restart in place (seconds); pass `new_schema` for indexing-code changes and the script runs
+the A/B rebuild-from-cache + parity check + flip automatically.
+
 ## Deploy
 ```sh
 cd atp-indexer/single-instance

--- a/atp-indexer/single-instance/data.tf
+++ b/atp-indexer/single-instance/data.tf
@@ -1,0 +1,34 @@
+# Reuse the SAME shared CloudFront secret + WAF the existing atp-indexer fleet uses, so a
+# prod CloudFront-front deploy needs no manual secret/WAF inputs (and matches the current
+# security posture exactly). Mirrors atp-indexer/terraform/data.tf. The si_cf_web_acl_arn /
+# cloudfront_secret_header_value vars override these if you ever need to.
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "aztec-token-sale-terraform-state"
+    key    = "${local.si_env_parent}/backends/ignition-infrastructure/terraform.tfstate"
+    region = "eu-west-2"
+  }
+}
+
+locals {
+  si_env_parent = var.env_parent != "" ? var.env_parent : var.env
+
+  # SSM name of the shared CloudFront secret value (read its current value below).
+  cf_secret_ssm_name = try(data.terraform_remote_state.shared.outputs.cloudfront_secret_header_ssm_name, "")
+
+  # CLOUDFRONT-scoped WAF — explicit var wins, else the shared backend WAF (same one the
+  # existing atp-indexer CloudFront attaches).
+  cf_waf_arn_resolved = var.si_cf_web_acl_arn != null ? var.si_cf_web_acl_arn : try(data.terraform_remote_state.shared.outputs.backend_waf_arn, null)
+}
+
+data "aws_ssm_parameter" "cf_secret" {
+  count = local.cf_secret_ssm_name != "" ? 1 : 0
+  name  = local.cf_secret_ssm_name
+}
+
+locals {
+  # Secret value: explicit var wins, else the shared SSM value. Used only in CloudFront mode.
+  cf_secret_value = var.cloudfront_secret_header_value != "" ? var.cloudfront_secret_header_value : try(data.aws_ssm_parameter.cf_secret[0].value, "")
+}

--- a/atp-indexer/single-instance/main.tf
+++ b/atp-indexer/single-instance/main.tf
@@ -1,0 +1,54 @@
+# Single-instance stack for the staking-dashboard atp-indexer.
+#
+# Collapses the atp-indexer's per-env ECS + Aurora + ALB onto ONE EC2 box running the
+# atp-indexer (this repo's own image — it indexes ATP_FACTORY_MATP etc. that ignition's
+# does not, so the two are NOT interchangeable) against a LOCAL Postgres, fronted by Caddy
+# (Caddy-direct TLS for testnet, or CloudFront-front for prod). Mirrors the ignition
+# single-instance pattern (intentional duplication — the repos are decoupled).
+#
+# This is an ADDITIVE stack with its own state. Standing it up does not touch the existing
+# atp-indexer/terraform stack; cutover (repoint the frontend's indexer URL to this box's
+# CloudFront, then tear down the old ECS/Aurora/ALB) is a separate, explicit step. See README.
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  # Partial config — `key` is supplied at `terraform init` (see README), e.g.
+  #   <env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate
+  backend "s3" {
+    bucket  = "aztec-token-sale-terraform-state"
+    region  = "eu-west-2"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = { Environment = var.env }
+  }
+}
+
+# CloudFront + CLOUDFRONT-scoped WAF/ACM require us-east-1.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = { Environment = var.env }
+  }
+}
+
+locals {
+  si_name = "staking-dashboard-atp-single-instance-${var.env}"
+  si_tags = {
+    Name        = local.si_name
+    Environment = var.env
+    CostPlan    = "single-instance"
+  }
+}

--- a/atp-indexer/single-instance/scripts/box-deploy.sh
+++ b/atp-indexer/single-instance/scripts/box-deploy.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Deploy an atp-indexer image to this box. Runs ON the box (the deploy workflow pushes and
+# invokes it via SSM).
+#
+#   box-deploy.sh IMAGE            metadata-only / same-app update: pull + restart. The
+#                                  container adopts the current schema (same Ponder build
+#                                  fingerprint) and is back at head in seconds.
+#   box-deploy.sh IMAGE NEW_SCHEMA indexing-code update: Ponder refuses to reuse the old
+#                                  app's schema, so run the new build as a parallel container
+#                                  against NEW_SCHEMA (rebuilds from the shared ponder_sync
+#                                  cache, minutes, no RPC refetch), sanity-check row counts,
+#                                  then flip the serving container. The old schema stays in
+#                                  Postgres as the instant rollback.
+set -euo pipefail
+
+APP_DIR=/opt/staking-dashboard-atp
+IMAGE="${1:?usage: box-deploy.sh IMAGE [NEW_SCHEMA]}"
+NEW_SCHEMA="${2:-}"
+cd "$APP_DIR"
+
+compose() { docker compose "$@"; }
+
+current_schema() {
+  compose exec -T atp-indexer sh -c 'echo $DATABASE_SCHEMA' 2>/dev/null | tr -d '\r' || true
+}
+
+write_override() { # $1=image $2=schema
+  cat > docker-compose.override.yml <<EOF
+# Written by box-deploy.sh — the currently served image + schema.
+services:
+  atp-indexer:
+    image: $1
+    environment:
+      DATABASE_SCHEMA: "$2"
+EOF
+}
+
+wait_ready() { # $1=service $2=port $3=timeout_s
+  for _ in $(seq 1 "$(($3 / 5))"); do
+    if compose exec -T "$1" wget -qO- "http://localhost:$2/ready" >/dev/null 2>&1; then return 0; fi
+    sleep 5
+  done
+  return 1
+}
+
+./refresh-ecr-login.sh >/dev/null
+[ -x ./fetch-env.sh ] && ./fetch-env.sh || true
+grep -q '^RPC_URL=' env/atp-indexer.env || { echo "env/atp-indexer.env not populated; aborting" >&2; exit 1; }
+docker pull "$IMAGE" >/dev/null
+
+CURRENT="$(current_schema)"
+echo "current schema: ${CURRENT:-<none>}  requested: ${NEW_SCHEMA:-<same>}"
+
+if [ -z "$NEW_SCHEMA" ] || [ "$NEW_SCHEMA" = "$CURRENT" ]; then
+  # Same-app update: swap the image in place.
+  write_override "$IMAGE" "${CURRENT:?cannot determine current schema; pass NEW_SCHEMA explicitly}"
+  compose up -d atp-indexer
+  wait_ready atp-indexer 42068 120 || { echo "serving container failed /ready after image swap" >&2; exit 1; }
+  echo "deployed $IMAGE on schema $CURRENT"
+  exit 0
+fi
+
+# A/B: build the new schema in a parallel container while the current one keeps serving.
+cat > docker-compose.ab.yml <<EOF
+services:
+  atp-indexer-next:
+    image: $IMAGE
+    restart: unless-stopped
+    command: ["yarn", "start"]
+    env_file: [./env/atp-indexer.env]
+    environment:
+      POSTGRES_CONNECTION_STRING: "postgresql://ponder:ponder@local-postgres:5432/ponder"
+      DATABASE_SCHEMA: "$NEW_SCHEMA"
+      NODE_ENV: "production"
+      PORT: "42069"
+    depends_on:
+      local-postgres: { condition: service_healthy }
+EOF
+compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ab.yml up -d atp-indexer-next
+
+echo "waiting for the new schema to rebuild from the ponder_sync cache (timeout 45m)..."
+for _ in $(seq 1 270); do
+  if compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ab.yml logs atp-indexer-next 2>/dev/null | grep -q 'Completed backfill indexing'; then
+    break
+  fi
+  sleep 10
+done
+compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ab.yml logs atp-indexer-next 2>/dev/null | grep -q 'Completed backfill indexing' \
+  || { echo "backfill did not complete in time; leaving current container serving" >&2; exit 1; }
+
+# Sanity: the new schema must hold at least as much history as the old (staking is live, so
+# strictly-fewer rows means the rebuild is wrong).
+psql_count() { compose exec -T local-postgres psql -U ponder -d ponder -tAc "select count(*) from \"$1\".atp_position" 2>/dev/null | tr -d '\r'; }
+OLD_N="$(psql_count "$CURRENT")"; NEW_N="$(psql_count "$NEW_SCHEMA")"
+echo "atp_position: old($CURRENT)=$OLD_N new($NEW_SCHEMA)=$NEW_N"
+[ -n "$NEW_N" ] && [ "$NEW_N" -ge "${OLD_N:-0}" ] || { echo "parity check failed; not flipping" >&2; exit 1; }
+
+# Flip: serve the new image+schema, retire the builder.
+write_override "$IMAGE" "$NEW_SCHEMA"
+compose up -d atp-indexer
+wait_ready atp-indexer 42068 120 || { echo "serving container failed /ready after flip" >&2; exit 1; }
+compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ab.yml rm -sf atp-indexer-next >/dev/null 2>&1 || true
+rm -f docker-compose.ab.yml
+echo "deployed $IMAGE on schema $NEW_SCHEMA (previous schema $CURRENT retained as rollback)"

--- a/atp-indexer/single-instance/single-instance-backup.tf
+++ b/atp-indexer/single-instance/single-instance-backup.tf
@@ -1,0 +1,61 @@
+# Automated backup of the single-instance /data volume (Postgres incl. the ponder_sync
+# cache). That volume is the box's durable state — staking is live, so unlike a finished
+# auction the data keeps changing — and Data Lifecycle Manager takes daily EBS snapshots of
+# it, pruning to a retention window. One snapshot captures everything on /data at once.
+
+variable "si_backup_retain_days" {
+  description = "Number of daily /data EBS snapshots to retain"
+  type        = number
+  default     = 7
+}
+
+# DLM assumes this role to create/delete the snapshots.
+resource "aws_iam_role" "dlm" {
+  name = "${local.si_name}-dlm"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "dlm.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.si_tags
+}
+
+resource "aws_iam_role_policy_attachment" "dlm" {
+  role       = aws_iam_role.dlm.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "data" {
+  description        = "${local.si_name} data volume daily snapshots"
+  execution_role_arn = aws_iam_role.dlm.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+    # Matches the Backup tag on aws_ebs_volume.data.
+    target_tags = {
+      Backup = "${local.si_name}-data"
+    }
+
+    schedule {
+      name = "daily"
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["03:00"]
+      }
+      retain_rule {
+        count = var.si_backup_retain_days
+      }
+      copy_tags = true
+      tags_to_add = {
+        SnapshotType = "${local.si_name}-data-daily"
+      }
+    }
+  }
+
+  tags = local.si_tags
+}

--- a/atp-indexer/single-instance/single-instance-cloudfront.tf
+++ b/atp-indexer/single-instance/single-instance-cloudfront.tf
@@ -1,0 +1,120 @@
+# Prod CloudFront-front for the box (gated on si_front_with_cloudfront). One distribution
+# fronting the indexer hostname: ACM (us-east-1), http-only origin via a stable si-origin
+# A-record -> EIP, the secret header injected (Caddy enforces it). Mirrors ignition's
+# single-instance-cloudfront.tf. NOT applied by default. See README for cutover.
+
+locals {
+  si_cf_enabled     = var.si_front_with_cloudfront ? 1 : 0
+  si_cf_origin_id   = "atp-single-instance-origin"
+  si_cf_origin_fqdn = "atp-si-origin.${var.env}.stake.aztec.network"
+}
+
+resource "aws_route53_record" "cf_origin" {
+  count   = local.si_cf_enabled
+  zone_id = data.aws_route53_zone.zone[0].zone_id
+  name    = local.si_cf_origin_fqdn
+  type    = "A"
+  ttl     = 60
+  records = [aws_eip.this.public_ip]
+}
+
+resource "aws_acm_certificate" "cf" {
+  count             = local.si_cf_enabled
+  provider          = aws.us_east_1
+  domain_name       = var.si_atp_indexer_domain
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = local.si_tags
+}
+
+resource "aws_route53_record" "cf_cert_validation" {
+  for_each = local.si_cf_enabled == 1 ? {
+    for o in aws_acm_certificate.cf[0].domain_validation_options : o.domain_name => {
+      name = o.resource_record_name, type = o.resource_record_type, record = o.resource_record_value
+    }
+  } : {}
+  zone_id         = data.aws_route53_zone.zone[0].zone_id
+  name            = each.value.name
+  type            = each.value.type
+  ttl             = 60
+  records         = [each.value.record]
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "cf" {
+  count                   = local.si_cf_enabled
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.cf[0].arn
+  validation_record_fqdns = [for r in aws_route53_record.cf_cert_validation : r.fqdn]
+}
+
+resource "aws_cloudfront_distribution" "front" {
+  count      = local.si_cf_enabled
+  enabled    = true
+  aliases    = [var.si_atp_indexer_domain]
+  web_acl_id = var.si_cf_web_acl_arn
+  comment    = "staking-dashboard atp single-instance front (${var.env})"
+
+  origin {
+    domain_name = local.si_cf_origin_fqdn
+    origin_id   = local.si_cf_origin_id
+    custom_origin_config {
+      # http-only matches the old ALB origins and avoids the LE-cert-on-box problem (the
+      # hostname resolves to CloudFront). The secret header gates the origin.
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+    dynamic "custom_header" {
+      for_each = var.cloudfront_secret_header_value != "" ? [1] : []
+      content {
+        name  = var.cloudfront_secret_header_name
+        value = var.cloudfront_secret_header_value
+      }
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = local.si_cf_origin_id
+    compress                 = true
+    viewer_protocol_policy   = "redirect-to-https"
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingDisabled
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # Managed-AllViewer
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cf[0].certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = merge(local.si_tags, { Type = "cdn" })
+}
+
+resource "aws_route53_record" "cf_alias" {
+  count   = local.si_cf_enabled
+  zone_id = data.aws_route53_zone.zone[0].zone_id
+  name    = var.si_atp_indexer_domain
+  type    = "A"
+  alias {
+    name                   = aws_cloudfront_distribution.front[0].domain_name
+    zone_id                = aws_cloudfront_distribution.front[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront domain for the box (point the frontend's indexer URL here at cutover)"
+  value       = one(aws_cloudfront_distribution.front[*].domain_name)
+}

--- a/atp-indexer/single-instance/single-instance-cloudfront.tf
+++ b/atp-indexer/single-instance/single-instance-cloudfront.tf
@@ -118,3 +118,11 @@ output "cloudfront_domain_name" {
   description = "CloudFront domain for the box (point the frontend's indexer URL here at cutover)"
   value       = one(aws_cloudfront_distribution.front[*].domain_name)
 }
+
+# Compatibility alias: the staking-dashboard frontend reads `cf_domain_name` from the
+# atp-indexer remote state (staking-dashboard/terraform/data.tf). Expose the same name so
+# the frontend can be repointed at this stack's state with no output rename.
+output "cf_domain_name" {
+  description = "Alias of cloudfront_domain_name matching the old atp-indexer stack's output name"
+  value       = one(aws_cloudfront_distribution.front[*].domain_name)
+}

--- a/atp-indexer/single-instance/single-instance-cloudfront.tf
+++ b/atp-indexer/single-instance/single-instance-cloudfront.tf
@@ -119,10 +119,12 @@ output "cloudfront_domain_name" {
   value       = one(aws_cloudfront_distribution.front[*].domain_name)
 }
 
-# Compatibility alias: the staking-dashboard frontend reads `cf_domain_name` from the
-# atp-indexer remote state (staking-dashboard/terraform/data.tf). Expose the same name so
-# the frontend can be repointed at this stack's state with no output rename.
+# The staking-dashboard frontend reads `cf_domain_name` from the atp-indexer remote state
+# (staking-dashboard/terraform/data.tf) to build the indexer URL. Expose the same name in
+# BOTH modes so the frontend can be repointed at this stack's state with no output rename:
+# - CloudFront-front (prod): the CloudFront distribution domain.
+# - Caddy-direct (testnet): the indexer hostname (resolves to the EIP, Caddy serves TLS).
 output "cf_domain_name" {
-  description = "Alias of cloudfront_domain_name matching the old atp-indexer stack's output name"
-  value       = one(aws_cloudfront_distribution.front[*].domain_name)
+  description = "Indexer endpoint host for the frontend (CloudFront domain in CF mode; the indexer hostname otherwise)"
+  value       = var.si_front_with_cloudfront ? one(aws_cloudfront_distribution.front[*].domain_name) : var.si_atp_indexer_domain
 }

--- a/atp-indexer/single-instance/single-instance-cloudfront.tf
+++ b/atp-indexer/single-instance/single-instance-cloudfront.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "front" {
   count      = local.si_cf_enabled
   enabled    = true
   aliases    = [var.si_atp_indexer_domain]
-  web_acl_id = var.si_cf_web_acl_arn
+  web_acl_id = local.cf_waf_arn_resolved
   comment    = "staking-dashboard atp single-instance front (${var.env})"
 
   origin {
@@ -69,10 +69,10 @@ resource "aws_cloudfront_distribution" "front" {
       origin_ssl_protocols   = ["TLSv1.2"]
     }
     dynamic "custom_header" {
-      for_each = var.cloudfront_secret_header_value != "" ? [1] : []
+      for_each = local.cf_secret_value != "" ? [1] : []
       content {
         name  = var.cloudfront_secret_header_name
-        value = var.cloudfront_secret_header_value
+        value = local.cf_secret_value
       }
     }
   }

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -164,6 +164,17 @@ resource "aws_instance" "this" {
     start_services_on_boot = var.si_start_services_on_boot
   })
 
+  lifecycle {
+    precondition {
+      condition     = !(var.si_create_dns_records && var.si_front_with_cloudfront)
+      error_message = "si_create_dns_records and si_front_with_cloudfront are mutually exclusive (both would own the same A-record). Use Caddy-direct OR CloudFront-front, not both."
+    }
+    precondition {
+      condition     = !var.si_front_with_cloudfront || var.cloudfront_secret_header_value != ""
+      error_message = "cloudfront_secret_header_value must be non-empty when si_front_with_cloudfront=true: Caddy enforces the secret header in that mode, so an empty value would reject every request."
+    }
+  }
+
   tags = local.si_tags
 }
 

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -1,0 +1,204 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
+    name   = "availability-zone"
+    values = [data.aws_availability_zones.available.names[0]]
+  }
+}
+
+data "aws_subnet" "public" {
+  id = data.aws_subnets.default.ids[0]
+}
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-kernel-6.1-x86_64"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name        = "${local.si_name}-instance"
+  description = "Public HTTP/HTTPS for the staking-dashboard atp-indexer single instance"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.si_allowed_http_cidrs
+  }
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.si_allowed_http_cidrs
+  }
+  egress {
+    description = "Outbound internet"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.si_tags
+}
+
+resource "aws_iam_role" "instance" {
+  name = "${local.si_name}-instance"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+  tags = local.si_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Pull the atp-indexer image from this repo's existing ECR repository.
+resource "aws_iam_role_policy" "ecr_read" {
+  name = "${local.si_name}-ecr-read"
+  role = aws_iam_role.instance.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer"
+        ]
+        Resource = "arn:aws:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${local.si_name}-instance"
+  role = aws_iam_role.instance.name
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = data.aws_subnet.public.availability_zone
+  size              = var.si_data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  tags              = merge(local.si_tags, { Name = "${local.si_name}-data" })
+}
+
+resource "aws_instance" "this" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = var.si_instance_type
+  subnet_id                   = data.aws_subnet.public.id
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.instance.id]
+  iam_instance_profile        = aws_iam_instance_profile.instance.name
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {
+    region            = var.region
+    account_id        = data.aws_caller_identity.current.account_id
+    volume_id_no_dash = replace(aws_ebs_volume.data.id, "-", "")
+    compose_b64 = base64encode(templatefile("${path.module}/templates/docker-compose.yml.tftpl", {
+      atp_indexer_image              = var.si_atp_indexer_image
+      atp_postgres_connection_string = "postgresql://ponder:ponder@local-postgres:5432/ponder"
+      atp_database_schema            = var.si_atp_database_schema
+    }))
+    caddyfile_b64 = base64encode(templatefile("${path.module}/templates/Caddyfile.tftpl", {
+      acme_email             = var.si_acme_email
+      atp_indexer_domain     = var.si_atp_indexer_domain
+      cloudfront_front       = var.si_front_with_cloudfront
+      cf_secret_header_name  = var.cloudfront_secret_header_name
+      cf_secret_header_value = var.cloudfront_secret_header_value
+    }))
+    start_services_on_boot = var.si_start_services_on_boot
+  })
+
+  tags = local.si_tags
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/xvdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.this.id
+}
+
+resource "aws_eip" "this" {
+  domain   = "vpc"
+  instance = aws_instance.this.id
+  tags     = local.si_tags
+}
+
+data "aws_route53_zone" "zone" {
+  count        = var.si_create_dns_records || var.si_front_with_cloudfront ? 1 : 0
+  name         = var.si_route53_zone_name
+  private_zone = false
+}
+
+# Caddy-direct: hostname -> the instance EIP (testnet). Mutually exclusive with CloudFront-front.
+resource "aws_route53_record" "direct" {
+  count   = var.si_create_dns_records ? 1 : 0
+  zone_id = data.aws_route53_zone.zone[0].zone_id
+  name    = var.si_atp_indexer_domain
+  type    = "A"
+  ttl     = 60
+  records = [aws_eip.this.public_ip]
+}
+
+output "instance_public_ip" {
+  value = aws_eip.this.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -40,24 +40,36 @@ data "aws_ami" "al2023" {
   }
 }
 
+# In CloudFront-front mode, restrict ingress to CloudFront's origin-facing ranges
+# (defense-in-depth on top of the Caddy secret-header gate). SSM is egress-based, so remote
+# access still works.
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  count = var.si_front_with_cloudfront ? 1 : 0
+  name  = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 resource "aws_security_group" "instance" {
   name        = "${local.si_name}-instance"
   description = "Public HTTP/HTTPS for the staking-dashboard atp-indexer single instance"
   vpc_id      = data.aws_vpc.default.id
 
+  # CloudFront-front: lock to the CloudFront prefix list (no public CIDRs). Caddy-direct:
+  # open to var.si_allowed_http_cidrs (needed for Let's Encrypt http-01 + direct access).
   ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = var.si_allowed_http_cidrs
+    description     = "HTTP"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    cidr_blocks     = var.si_front_with_cloudfront ? [] : var.si_allowed_http_cidrs
+    prefix_list_ids = data.aws_ec2_managed_prefix_list.cloudfront[*].id
   }
   ingress {
-    description = "HTTPS"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.si_allowed_http_cidrs
+    description     = "HTTPS"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks     = var.si_front_with_cloudfront ? [] : var.si_allowed_http_cidrs
+    prefix_list_ids = data.aws_ec2_managed_prefix_list.cloudfront[*].id
   }
   egress {
     description = "Outbound internet"

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -171,7 +171,7 @@ resource "aws_instance" "this" {
       atp_indexer_domain     = var.si_atp_indexer_domain
       cloudfront_front       = var.si_front_with_cloudfront
       cf_secret_header_name  = var.cloudfront_secret_header_name
-      cf_secret_header_value = var.cloudfront_secret_header_value
+      cf_secret_header_value = local.cf_secret_value
     }))
     start_services_on_boot = var.si_start_services_on_boot
   })
@@ -182,8 +182,8 @@ resource "aws_instance" "this" {
       error_message = "si_create_dns_records and si_front_with_cloudfront are mutually exclusive (both would own the same A-record). Use Caddy-direct OR CloudFront-front, not both."
     }
     precondition {
-      condition     = !var.si_front_with_cloudfront || var.cloudfront_secret_header_value != ""
-      error_message = "cloudfront_secret_header_value must be non-empty when si_front_with_cloudfront=true: Caddy enforces the secret header in that mode, so an empty value would reject every request."
+      condition     = !var.si_front_with_cloudfront || local.cf_secret_value != ""
+      error_message = "The CloudFront secret header resolved empty in CloudFront mode. Either the shared SSM secret (cloudfront_secret_header_ssm_name in the ignition-infrastructure state) isn't populated, or set cloudfront_secret_header_value. Caddy enforces the header, so empty would reject every request."
     }
   }
 

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -63,13 +63,18 @@ resource "aws_security_group" "instance" {
     cidr_blocks     = var.si_front_with_cloudfront ? [] : var.si_allowed_http_cidrs
     prefix_list_ids = data.aws_ec2_managed_prefix_list.cloudfront[*].id
   }
-  ingress {
-    description     = "HTTPS"
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    cidr_blocks     = var.si_front_with_cloudfront ? [] : var.si_allowed_http_cidrs
-    prefix_list_ids = data.aws_ec2_managed_prefix_list.cloudfront[*].id
+  # HTTPS only in Caddy-direct mode. Behind CloudFront, Caddy serves plain HTTP on :80
+  # (CloudFront terminates viewer TLS), and the CloudFront origin-facing prefix list is
+  # large enough that attaching it to a second port exceeds the per-security-group rule quota.
+  dynamic "ingress" {
+    for_each = var.si_front_with_cloudfront ? [] : [443]
+    content {
+      description = "HTTPS"
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      cidr_blocks = var.si_allowed_http_cidrs
+    }
   }
   egress {
     description = "Outbound internet"
@@ -135,7 +140,12 @@ resource "aws_ebs_volume" "data" {
   size              = var.si_data_volume_size_gb
   type              = "gp3"
   encrypted         = true
-  tags              = merge(local.si_tags, { Name = "${local.si_name}-data" })
+  # The Backup tag is what the DLM policy (single-instance-backup.tf) targets for daily
+  # snapshots; keyed per environment so each box's policy only snapshots its own volume.
+  tags = merge(local.si_tags, {
+    Name   = "${local.si_name}-data"
+    Backup = "${local.si_name}-data"
+  })
 }
 
 resource "aws_instance" "this" {

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -185,6 +185,10 @@ resource "aws_instance" "this" {
       condition     = !var.si_front_with_cloudfront || local.cf_secret_value != ""
       error_message = "The CloudFront secret header resolved empty in CloudFront mode. Either the shared SSM secret (cloudfront_secret_header_ssm_name in the ignition-infrastructure state) isn't populated, or set cloudfront_secret_header_value. Caddy enforces the header, so empty would reject every request."
     }
+    precondition {
+      condition     = !var.si_front_with_cloudfront || local.cf_waf_arn_resolved != null
+      error_message = "The CLOUDFRONT-scoped WAF resolved null in CloudFront mode. Ensure the shared ignition-infrastructure state (key ${local.si_env_parent}/backends/ignition-infrastructure/terraform.tfstate) exposes backend_waf_arn, or set si_cf_web_acl_arn. Refusing to front the box without a WAF."
+    }
   }
 
   tags = local.si_tags

--- a/atp-indexer/single-instance/single-instance.tf
+++ b/atp-indexer/single-instance/single-instance.tf
@@ -125,6 +125,13 @@ resource "aws_iam_role_policy" "ecr_read" {
           "ecr:GetDownloadUrlForLayer"
         ]
         Resource = "arn:aws:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+      },
+      {
+        # Runtime env for the indexer (fetch-env.sh); the parameter is created out-of-band so
+        # its values stay out of Terraform state.
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter"]
+        Resource = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/staking-dashboard-atp/${var.env}/*"
       }
     ]
   })
@@ -168,6 +175,7 @@ resource "aws_instance" "this" {
   }
 
   user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {
+    env               = var.env
     region            = var.region
     account_id        = data.aws_caller_identity.current.account_id
     volume_id_no_dash = replace(aws_ebs_volume.data.id, "-", "")

--- a/atp-indexer/single-instance/templates/Caddyfile.tftpl
+++ b/atp-indexer/single-instance/templates/Caddyfile.tftpl
@@ -1,0 +1,23 @@
+{
+	email ${acme_email}
+%{ if cloudfront_front ~}
+	# CloudFront terminates viewer TLS; the box serves plain HTTP to CloudFront only.
+	auto_https off
+%{ endif ~}
+}
+
+%{ if cloudfront_front ~}
+# Only accept requests carrying CloudFront's secret header, so the origin EIP isn't usable
+# directly (mirrors the old ALB listener gate).
+(cfgate) {
+	@nocf not header ${cf_secret_header_name} "${cf_secret_header_value}"
+	abort @nocf
+}
+%{ endif ~}
+
+%{ if cloudfront_front ~}http://${atp_indexer_domain}%{ else ~}${atp_indexer_domain}%{ endif } {
+%{ if cloudfront_front ~}
+	import cfgate
+%{ endif ~}
+	reverse_proxy atp-indexer:42068
+}

--- a/atp-indexer/single-instance/templates/docker-compose.yml.tftpl
+++ b/atp-indexer/single-instance/templates/docker-compose.yml.tftpl
@@ -1,0 +1,68 @@
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - /data/caddy/data:/data
+      - /data/caddy/config:/config
+    depends_on:
+      - atp-indexer
+
+  # Local Postgres replaces the per-env Aurora cluster. EBS-persistent so a restart
+  # crash-recovers/resumes instead of reindexing.
+  local-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "ponder"
+      POSTGRES_USER: "ponder"
+      POSTGRES_PASSWORD: "ponder"
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=512MB"
+      - "-c"
+      - "effective_cache_size=1536MB"
+      - "-c"
+      - "max_connections=80"
+      - "-c"
+      - "checkpoint_timeout=30min"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "synchronous_commit=off"
+      - "-c"
+      - "wal_compression=on"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ponder -d ponder"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - /data/postgres:/var/lib/postgresql/data
+
+  # This repo's atp-indexer image (indexes ATP_FACTORY_MATP/LATP etc.). Contract addresses,
+  # RPC_URL, CHAIN_ID and start blocks come from ./env/atp-indexer.env (kept out of state).
+  atp-indexer:
+    image: ${atp_indexer_image}
+    restart: unless-stopped
+    command: ["yarn", "start"]
+    env_file:
+      - ./env/atp-indexer.env
+    environment:
+      POSTGRES_CONNECTION_STRING: "${atp_postgres_connection_string}"
+      DATABASE_SCHEMA: "${atp_database_schema}"
+      NODE_ENV: "production"
+      PORT: "42068"
+      API_PORT: "42068"
+      LOG_LEVEL: "info"
+      PONDER_LOG_LEVEL: "info"
+    volumes:
+      - /data/atp-indexer/.ponder:/app/.ponder
+    depends_on:
+      local-postgres:
+        condition: service_healthy

--- a/atp-indexer/single-instance/templates/docker-compose.yml.tftpl
+++ b/atp-indexer/single-instance/templates/docker-compose.yml.tftpl
@@ -57,8 +57,9 @@ services:
       POSTGRES_CONNECTION_STRING: "${atp_postgres_connection_string}"
       DATABASE_SCHEMA: "${atp_database_schema}"
       NODE_ENV: "production"
+      # `yarn start` (ponder start) indexes AND serves the API on PORT — it's the all-in-one,
+      # so the separate `yarn serve` API server (and its API_PORT) isn't needed on the box.
       PORT: "42068"
-      API_PORT: "42068"
       LOG_LEVEL: "info"
       PONDER_LOG_LEVEL: "info"
     volumes:

--- a/atp-indexer/single-instance/templates/user_data.sh.tftpl
+++ b/atp-indexer/single-instance/templates/user_data.sh.tftpl
@@ -58,11 +58,15 @@ env_file="$APP_DIR/env/atp-indexer.env"
 if [ ! -f "$env_file" ]; then
   cat > "$env_file" <<'EOF'
 # Populate before starting Docker Compose (keep secrets out of Terraform state).
+# Copy the FULL set from the ECS task-def (atp-indexer/terraform/app.tf -> indexer_env_vars,
+# ~25 vars) so behaviour matches exactly.
 # Required: RPC_URL, CHAIN_ID, START_BLOCK,
 #   ATP_FACTORY_ADDRESS, ATP_FACTORY_AUCTION_ADDRESS, ATP_FACTORY_MATP_ADDRESS,
 #   ATP_FACTORY_LATP_ADDRESS, STAKING_REGISTRY_ADDRESS, REGISTRY_ADDRESS,
 #   REGISTRY_START_BLOCK, MATP_FACTORY_START_BLOCK, LATP_FACTORY_START_BLOCK.
-# (Same values the ECS task-def used; see atp-indexer/terraform/app.tf.)
+# Tuning (image defaults if omitted): BLOCK_BATCH_SIZE, POLLING_INTERVAL, MAX_RETRIES,
+#   PARALLEL_BATCHES, CLEANUP_ENABLED, CLEANUP_INTERVAL_BLOCKS, CLEANUP_KEEP_BLOCKS,
+#   TRUST_PROXY, PONDER_TELEMETRY_DISABLED.
 EOF
 fi
 

--- a/atp-indexer/single-instance/templates/user_data.sh.tftpl
+++ b/atp-indexer/single-instance/templates/user_data.sh.tftpl
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf update -y
+dnf install -y docker jq xfsprogs
+systemctl enable --now docker
+
+mkdir -p /usr/local/lib/docker/cli-plugins
+curl -SL "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose
+chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+usermod -aG docker ec2-user || true
+
+DATA_DEVICE="/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${volume_id_no_dash}"
+for attempt in $(seq 1 60); do
+  if [ -b "$DATA_DEVICE" ]; then
+    break
+  fi
+  sleep 2
+done
+
+if [ ! -b "$DATA_DEVICE" ]; then
+  echo "Data volume was not attached at $DATA_DEVICE" >&2
+  exit 1
+fi
+
+DATA_LABEL="atpsidata"
+
+if ! blkid "$DATA_DEVICE"; then
+  mkfs.xfs -L "$DATA_LABEL" "$DATA_DEVICE"
+fi
+
+mkdir -p /data
+if ! grep -q "$DATA_LABEL" /etc/fstab; then
+  echo "LABEL=$DATA_LABEL /data xfs defaults,nofail 0 2" >> /etc/fstab
+fi
+mount -a
+
+APP_DIR="/opt/staking-dashboard-atp"
+mkdir -p \
+  "$APP_DIR/env" \
+  /data/atp-indexer/.ponder \
+  /data/caddy/data \
+  /data/caddy/config \
+  /data/postgres
+
+echo "${compose_b64}" | base64 -d > "$APP_DIR/docker-compose.yml"
+echo "${caddyfile_b64}" | base64 -d > "$APP_DIR/Caddyfile"
+
+cat > "$APP_DIR/refresh-ecr-login.sh" <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${region}.amazonaws.com
+SCRIPT
+chmod +x "$APP_DIR/refresh-ecr-login.sh"
+
+env_file="$APP_DIR/env/atp-indexer.env"
+if [ ! -f "$env_file" ]; then
+  cat > "$env_file" <<'EOF'
+# Populate before starting Docker Compose (keep secrets out of Terraform state).
+# Required: RPC_URL, CHAIN_ID, START_BLOCK,
+#   ATP_FACTORY_ADDRESS, ATP_FACTORY_AUCTION_ADDRESS, ATP_FACTORY_MATP_ADDRESS,
+#   ATP_FACTORY_LATP_ADDRESS, STAKING_REGISTRY_ADDRESS, REGISTRY_ADDRESS,
+#   REGISTRY_START_BLOCK, MATP_FACTORY_START_BLOCK, LATP_FACTORY_START_BLOCK.
+# (Same values the ECS task-def used; see atp-indexer/terraform/app.tf.)
+EOF
+fi
+
+chown -R ec2-user:ec2-user "$APP_DIR" /data
+
+"$APP_DIR/refresh-ecr-login.sh" || true
+
+if [ "${start_services_on_boot}" = "true" ]; then
+  cd "$APP_DIR"
+  docker compose up -d
+fi

--- a/atp-indexer/single-instance/templates/user_data.sh.tftpl
+++ b/atp-indexer/single-instance/templates/user_data.sh.tftpl
@@ -54,6 +54,25 @@ aws ecr get-login-password --region ${region} | docker login --username AWS --pa
 SCRIPT
 chmod +x "$APP_DIR/refresh-ecr-login.sh"
 
+# fetch-env.sh pulls the runtime env from SSM Parameter Store — the durable machine-readable
+# source (mirrors the GitHub environment vars the deploy workflow holds). Run it any time the
+# parameter changes; boot runs it automatically.
+cat > "$APP_DIR/fetch-env.sh" <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+PARAM="/staking-dashboard-atp/${env}/atp-indexer.env"
+if aws ssm get-parameter --region ${region} --name "$PARAM" --with-decryption --query 'Parameter.Value' --output text > /opt/staking-dashboard-atp/env/atp-indexer.env.tmp 2>/dev/null \
+   && grep -q '^RPC_URL=' /opt/staking-dashboard-atp/env/atp-indexer.env.tmp; then
+  mv /opt/staking-dashboard-atp/env/atp-indexer.env.tmp /opt/staking-dashboard-atp/env/atp-indexer.env
+  echo "env refreshed from $PARAM"
+else
+  rm -f /opt/staking-dashboard-atp/env/atp-indexer.env.tmp
+  echo "SSM parameter $PARAM missing or lacks RPC_URL; kept existing env file" >&2
+fi
+SCRIPT
+chmod +x "$APP_DIR/fetch-env.sh"
+"$APP_DIR/fetch-env.sh" || true
+
 env_file="$APP_DIR/env/atp-indexer.env"
 if [ ! -f "$env_file" ]; then
   cat > "$env_file" <<'EOF'
@@ -75,6 +94,12 @@ chown -R ec2-user:ec2-user "$APP_DIR" /data
 "$APP_DIR/refresh-ecr-login.sh" || true
 
 if [ "${start_services_on_boot}" = "true" ]; then
-  cd "$APP_DIR"
-  docker compose up -d
+  # Never start on a placeholder env — a missing RPC_URL surfaces only as a crash-looping
+  # container otherwise.
+  if grep -q '^RPC_URL=' "$env_file"; then
+    cd "$APP_DIR"
+    docker compose up -d
+  else
+    echo "env/atp-indexer.env is not populated (no RPC_URL); skipping service start" >&2
+  fi
 fi

--- a/atp-indexer/single-instance/variables.tf
+++ b/atp-indexer/single-instance/variables.tf
@@ -47,9 +47,9 @@ variable "si_atp_database_schema" {
 }
 
 variable "si_atp_indexer_domain" {
-  description = "Public hostname for the ATP indexer API"
+  description = "Public hostname for the ATP indexer API. Convention: api.<env>.stake.aztec.network, and api.stake.aztec.network for prod — one stable branded endpoint (instead of a raw *.cloudfront.net URL) so the frontend never changes when the infra behind it does."
   type        = string
-  default     = "indexer.testnet.stake.aztec.network"
+  default     = "api.testnet.stake.aztec.network"
 }
 
 variable "si_acme_email" {

--- a/atp-indexer/single-instance/variables.tf
+++ b/atp-indexer/single-instance/variables.tf
@@ -10,6 +10,12 @@ variable "region" {
   default     = "eu-west-2"
 }
 
+variable "env_parent" {
+  description = "Parent env for the shared ignition-infrastructure Terraform state (CloudFront secret + WAF). Defaults to env."
+  type        = string
+  default     = ""
+}
+
 variable "si_instance_type" {
   description = "EC2 instance size"
   type        = string
@@ -73,7 +79,7 @@ variable "si_front_with_cloudfront" {
 }
 
 variable "si_cf_web_acl_arn" {
-  description = "CLOUDFRONT-scoped WAFv2 WebACL ARN to attach (null = no WAF)"
+  description = "Override the CLOUDFRONT-scoped WAFv2 WebACL ARN. Default null = use the shared backend WAF from remote state (what the existing atp-indexer CloudFront uses)."
   type        = string
   default     = null
 }
@@ -85,7 +91,7 @@ variable "cloudfront_secret_header_name" {
 }
 
 variable "cloudfront_secret_header_value" {
-  description = "Value of the CloudFront secret header. REQUIRED (non-empty) when si_front_with_cloudfront=true — Caddy always enforces the header in that mode, so an empty value rejects every request (enforced by a precondition)."
+  description = "Override the CloudFront secret header value. Default empty = read the shared value from SSM (what the existing fleet uses). In CloudFront mode the resolved value must be non-empty (enforced by a precondition), since Caddy enforces the header."
   type        = string
   sensitive   = true
   default     = ""

--- a/atp-indexer/single-instance/variables.tf
+++ b/atp-indexer/single-instance/variables.tf
@@ -85,7 +85,7 @@ variable "cloudfront_secret_header_name" {
 }
 
 variable "cloudfront_secret_header_value" {
-  description = "Value of the CloudFront secret header (empty = no gate)"
+  description = "Value of the CloudFront secret header. REQUIRED (non-empty) when si_front_with_cloudfront=true — Caddy always enforces the header in that mode, so an empty value rejects every request (enforced by a precondition)."
   type        = string
   sensitive   = true
   default     = ""

--- a/atp-indexer/single-instance/variables.tf
+++ b/atp-indexer/single-instance/variables.tf
@@ -1,0 +1,98 @@
+variable "env" {
+  description = "Environment name (e.g. testnet, prod)"
+  type        = string
+  default     = "testnet"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "si_instance_type" {
+  description = "EC2 instance size"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "si_data_volume_size_gb" {
+  description = "Persistent /data EBS volume size (GB)"
+  type        = number
+  default     = 50
+}
+
+variable "si_allowed_http_cidrs" {
+  description = "CIDRs allowed to reach the instance on 80/443"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "si_atp_indexer_image" {
+  description = "ATP indexer image (this repo's image) for the single instance"
+  type        = string
+  default     = ""
+}
+
+variable "si_atp_database_schema" {
+  description = "Postgres schema the atp-indexer uses"
+  type        = string
+  default     = "atp_indexer"
+}
+
+variable "si_atp_indexer_domain" {
+  description = "Public hostname for the ATP indexer API"
+  type        = string
+  default     = "indexer.testnet.stake.aztec.network"
+}
+
+variable "si_acme_email" {
+  description = "Email for Caddy ACME registration (Caddy-direct mode)"
+  type        = string
+  default     = "ops@aztec.foundation"
+}
+
+variable "si_start_services_on_boot" {
+  description = "Start Docker Compose from user data (keep false until the env file is populated)"
+  type        = bool
+  default     = false
+}
+
+variable "si_create_dns_records" {
+  description = "Create a Route53 A record for the indexer hostname -> the instance EIP (Caddy-direct). Mutually exclusive with si_front_with_cloudfront."
+  type        = bool
+  default     = false
+}
+
+# --- Prod CloudFront-front (mirrors ignition's single-instance-cloudfront.tf) ---
+
+variable "si_front_with_cloudfront" {
+  description = "Prod: put CloudFront (CDN/WAF/DDoS/ACM) in front of the box instead of Caddy-direct"
+  type        = bool
+  default     = false
+}
+
+variable "si_cf_web_acl_arn" {
+  description = "CLOUDFRONT-scoped WAFv2 WebACL ARN to attach (null = no WAF)"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_secret_header_name" {
+  description = "Name of the secret header CloudFront injects and Caddy enforces"
+  type        = string
+  default     = "X-CloudFront-Secret"
+}
+
+variable "cloudfront_secret_header_value" {
+  description = "Value of the CloudFront secret header (empty = no gate)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "si_route53_zone_name" {
+  description = "Route53 hosted zone for the indexer hostname"
+  type        = string
+  default     = "aztec.network."
+}

--- a/atp-indexer/src/api/index.ts
+++ b/atp-indexer/src/api/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { globalLimiter } from './middleware/rate-limit';
+import { responseCache } from './middleware/response-cache';
 import { healthRoutes } from './routes/health.routes';
 import { providerRoutes } from './routes/provider.routes';
 import { stakingRoutes } from './routes/staking.routes';
@@ -30,6 +31,17 @@ if (config.RATE_LIMIT_ENABLED) {
 }
 
 app.route('/api/health', healthRoutes);
+
+// Response cache on the data routes only — health stays live for probes. Registered after
+// the health route so it never intercepts it.
+if (config.API_CACHE_TTL_MS > 0) {
+  const cached = responseCache(config.API_CACHE_TTL_MS);
+  app.use('/api/providers/*', cached);
+  app.use('/api/staking/*', cached);
+  app.use('/api/atp/*', cached);
+  app.use('/api/rollups/*', cached);
+}
+
 app.route('/api/providers', providerRoutes);
 app.route('/api/staking', stakingRoutes);
 app.route('/api/atp', atpRoutes);

--- a/atp-indexer/src/api/middleware/response-cache.ts
+++ b/atp-indexer/src/api/middleware/response-cache.ts
@@ -1,0 +1,60 @@
+import { Context, Next } from 'hono';
+
+/**
+ * Short-TTL response cache for the read-only /api/* GET routes.
+ *
+ * The dashboard polls the same handful of queries from every open session, so identical
+ * requests land in bursts. Indexed data only changes ~per block (~12s), which makes a
+ * few seconds of staleness invisible — one upstream execution per query shape per TTL
+ * window absorbs the burst before it reaches Postgres.
+ *
+ * Dependency-free on purpose: a Map with insertion-order eviction is plenty for the
+ * few dozen distinct query shapes the dashboard produces.
+ */
+
+interface CacheEntry {
+  body: string;
+  contentType: string;
+  expiresAt: number;
+}
+
+const MAX_ENTRIES = 500;
+
+export function responseCache(ttlMs: number) {
+  const cache = new Map<string, CacheEntry>();
+
+  return async (c: Context, next: Next) => {
+    if (c.req.method !== 'GET') {
+      return next();
+    }
+
+    const url = new URL(c.req.url);
+    const key = url.pathname + url.search;
+    const now = Date.now();
+
+    const hit = cache.get(key);
+    if (hit && hit.expiresAt > now) {
+      return new Response(hit.body, {
+        status: 200,
+        headers: { 'Content-Type': hit.contentType, 'X-Cache': 'HIT' },
+      });
+    }
+
+    await next();
+
+    if (c.res.status === 200) {
+      const body = await c.res.clone().text();
+      if (cache.size >= MAX_ENTRIES) {
+        // Maps iterate in insertion order, so the first key is the oldest entry.
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) cache.delete(oldest);
+      }
+      cache.set(key, {
+        body,
+        contentType: c.res.headers.get('Content-Type') ?? 'application/json',
+        expiresAt: now + ttlMs,
+      });
+      c.res.headers.set('X-Cache', 'MISS');
+    }
+  };
+}

--- a/atp-indexer/src/config/index.ts
+++ b/atp-indexer/src/config/index.ts
@@ -78,6 +78,9 @@ const configSchema = z.object({
 
   // Rate limiting (disabled by default)
   RATE_LIMIT_ENABLED: z.string().transform(val => val === 'true').default('false'),
+
+  // Short-TTL response cache for the read-only /api/* GET routes; 0 disables it.
+  API_CACHE_TTL_MS: z.string().transform(Number).pipe(z.number().int().min(0)).default('10000'),
 });
 
 /**

--- a/atp-indexer/src/events/staking-registry/attesters-added.ts
+++ b/atp-indexer/src/events/staking-registry/attesters-added.ts
@@ -6,9 +6,9 @@ ponder.on("StakingRegistry:AttestersAddedToProvider", async ({ event, context })
   const { providerIdentifier, attesters } = event.args;
   const { db } = context;
 
-  for (let i = 0; i < attesters.length; i++) {
-    const attester = attesters[i];
-    await db.insert(providerAttester).values({
+  // One batched insert instead of a round-trip per attester.
+  await db.insert(providerAttester).values(
+    attesters.map((attester, i) => ({
       id: `${event.transaction.hash}-${event.log.logIndex}-${i}`,
       providerIdentifier: providerIdentifier.toString(),
       attesterAddress: normalizeAddress(attester) as `0x${string}`,
@@ -16,8 +16,8 @@ ponder.on("StakingRegistry:AttestersAddedToProvider", async ({ event, context })
       txHash: event.transaction.hash,
       logIndex: event.log.logIndex,
       timestamp: event.block.timestamp,
-    });
-  }
+    })),
+  );
 
   console.log(`Added ${attesters.length} attesters to provider ${providerIdentifier}`);
 });

--- a/atp-indexer/src/utils/failed-deposits.ts
+++ b/atp-indexer/src/utils/failed-deposits.ts
@@ -37,7 +37,7 @@
 
 import { deposit, failedDeposit, withdrawFinalized, atpPosition, withdrawInitiated } from 'ponder:schema';
 import { normalizeAddress } from './address';
-import { and, eq, or, ReadonlyDrizzle } from 'ponder';
+import { eq, inArray, ReadonlyDrizzle } from 'ponder';
 
 export enum FailureReason {
   INVALID_KEY = 'Likely a Invalid Key',
@@ -78,55 +78,56 @@ export async function fetchFailedDeposits(
   }
   const distinctPairs = Array.from(uniquePairs.values());
 
-  const buildPairFilter = (table: any, pairs: any[]) => {
-    return or(
-      ...pairs.map((pair) =>
-        and(
-          eq(table.attesterAddress, normalizeAddress(pair.attesterAddress)),
-          eq(table.withdrawerAddress, normalizeAddress(pair.withdrawerAddress))
-        )
-      )
-    );
+  if (distinctPairs.length === 0) {
+    return new Map();
   }
 
+  // Filter in SQL by attester only (indexed, one IN list instead of an OR branch per pair —
+  // the OR-of-pairs form defeats the planner and sequential-scans every event table), then
+  // match the exact (attester, withdrawer) pairs in memory on the small result.
+  const distinctAttesters = Array.from(
+    new Set(distinctPairs.map((p) => normalizeAddress(p.attesterAddress) as `0x${string}`)),
+  );
+  const pairKeyOf = (attester: string, withdrawer: string) =>
+    `${attester.toLowerCase()}-${withdrawer.toLowerCase()}`;
+  const requestedPairs = new Set(
+    distinctPairs.map((p) => pairKeyOf(normalizeAddress(p.attesterAddress), normalizeAddress(p.withdrawerAddress))),
+  );
+
   // Fetch withdraw events and join with ATP to get staker/withdrawer address
-  const withdrawEvents = await db.select({
-    attesterAddress: withdrawFinalized.attesterAddress,
-    recipientAddress: withdrawFinalized.recipientAddress,
-    timestamp: withdrawFinalized.timestamp,
-    blockNumber: withdrawFinalized.blockNumber,
-    logIndex: withdrawFinalized.logIndex,
-    txHash: withdrawFinalized.txHash,
-    stakerAddress: atpPosition.stakerAddress,
-  })
-    .from(withdrawFinalized)
-    .leftJoin(atpPosition, eq(withdrawFinalized.recipientAddress, atpPosition.address))
-    .where(
-      or(
-        // ATP-based: match via ATP position (staker contract)
-        ...distinctPairs.map((pair) =>
-          and(
-            eq(withdrawFinalized.attesterAddress, normalizeAddress(pair.attesterAddress) as `0x${string}`),
-            eq(atpPosition.stakerAddress, normalizeAddress(pair.withdrawerAddress) as `0x${string}`)
-          )
-        ),
-        // ERC20-based: match directly via recipient address (user's EOA wallet)
-        ...distinctPairs.map((pair) =>
-          and(
-            eq(withdrawFinalized.attesterAddress, normalizeAddress(pair.attesterAddress) as `0x${string}`),
-            eq(withdrawFinalized.recipientAddress, normalizeAddress(pair.withdrawerAddress) as `0x${string}`)
-          )
-        )
-      )
-    );
+  const withdrawEvents = (
+    await db.select({
+      attesterAddress: withdrawFinalized.attesterAddress,
+      recipientAddress: withdrawFinalized.recipientAddress,
+      timestamp: withdrawFinalized.timestamp,
+      blockNumber: withdrawFinalized.blockNumber,
+      logIndex: withdrawFinalized.logIndex,
+      txHash: withdrawFinalized.txHash,
+      stakerAddress: atpPosition.stakerAddress,
+    })
+      .from(withdrawFinalized)
+      .leftJoin(atpPosition, eq(withdrawFinalized.recipientAddress, atpPosition.address))
+      .where(inArray(withdrawFinalized.attesterAddress, distinctAttesters))
+  ).filter(
+    (w) =>
+      // ATP-based: match via ATP position (staker contract)
+      (w.stakerAddress && requestedPairs.has(pairKeyOf(w.attesterAddress, w.stakerAddress))) ||
+      // ERC20-based: match directly via recipient address (user's EOA wallet)
+      requestedPairs.has(pairKeyOf(w.attesterAddress, w.recipientAddress)),
+  );
+
+  const matchesRequestedPair = (row: { attesterAddress: string; withdrawerAddress: string }) =>
+    requestedPairs.has(pairKeyOf(row.attesterAddress, row.withdrawerAddress));
 
   const [successfulDeposits, failedDeposits] = await Promise.all([
     db.select()
       .from(deposit)
-      .where(buildPairFilter(deposit, distinctPairs)),
+      .where(inArray(deposit.attesterAddress, distinctAttesters))
+      .then((rows) => rows.filter(matchesRequestedPair)),
     db.select()
       .from(failedDeposit)
-      .where(buildPairFilter(failedDeposit, distinctPairs))
+      .where(inArray(failedDeposit.attesterAddress, distinctAttesters))
+      .then((rows) => rows.filter(matchesRequestedPair)),
   ]);
 
   // Combine and Sort to create the "God View" timeline

--- a/staking-dashboard/terraform/main.tf
+++ b/staking-dashboard/terraform/main.tf
@@ -1,5 +1,5 @@
 locals {
-  create_dns_record = var.env == "prod" || var.env == "testnet" ? true : false
+  create_dns_record = contains(["prod", "testnet", "staging"], var.env)
 }
 terraform {
   required_version = ">= 1.5.0"
@@ -132,7 +132,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
 
   security_headers_config {
     strict_transport_security {
-      access_control_max_age_sec = 63072000  # 2 years
+      access_control_max_age_sec = 63072000 # 2 years
       include_subdomains         = true
       preload                    = true
       override                   = true
@@ -184,9 +184,10 @@ resource "aws_cloudfront_distribution" "staking_dashboard_distribution" {
   enabled             = true
   default_root_object = "index.html"
   web_acl_id          = module.website_waf.web_acl_arn
-  
-  # Use custom domain with certificate
-  aliases = var.env == "prod" ? ["stake.aztec.network"] : var.env == "testnet" ? ["testnet.stake.aztec.network"] : []
+
+  # Custom domain (stake.aztec.network for prod, <env>.stake.aztec.network otherwise) whenever
+  # the env owns a DNS record; matches module.domain so the cert and alias always agree.
+  aliases = local.create_dns_record ? [var.env == "prod" ? "stake.aztec.network" : "${var.env}.stake.aztec.network"] : []
 
   origin {
     domain_name              = aws_s3_bucket.staking_dashboard_bucket.bucket_regional_domain_name
@@ -208,7 +209,7 @@ resource "aws_cloudfront_distribution" "staking_dashboard_distribution" {
         forward = "none"
       }
     }
-    
+
   }
 
   # Redirect to blocked.html for 403 errors
@@ -231,7 +232,7 @@ resource "aws_cloudfront_distribution" "staking_dashboard_distribution" {
   restrictions {
     geo_restriction {
       restriction_type = "blacklist"
-      locations = var.blocked_jurisdictions
+      locations        = var.blocked_jurisdictions
     }
   }
 
@@ -257,20 +258,20 @@ resource "aws_cloudfront_distribution" "staking_dashboard_distribution" {
 #
 module "domain" {
   source = "../../terraform/modules/acm-certificate"
-  
+
   providers = {
     aws.us_east_1 = aws.us_east_1
   }
-  
+
   domain_name               = var.env == "prod" ? "stake.aztec.network" : "${var.env}.stake.aztec.network"
   subject_alternative_names = []
   hosted_zone_name          = "aztec.network"
-  
+
   # DNS record will be created after CloudFront distribution
   create_dns_record      = local.create_dns_record
   cloudfront_domain_name = aws_cloudfront_distribution.staking_dashboard_distribution.domain_name
   cloudfront_zone_id     = aws_cloudfront_distribution.staking_dashboard_distribution.hosted_zone_id
-  
+
   tags = {
     Environment = var.env
     Service     = "staking-dashboard"

--- a/staking-dashboard/terraform/waf.tf
+++ b/staking-dashboard/terraform/waf.tf
@@ -19,7 +19,7 @@ module "website_waf" {
   enable_sql_injection_rule_set     = false  # Not needed for static site
   enable_ip_reputation_list         = true
   enable_anon_ip_rule_set           = false
-  enable_bot_control_rule_set       = true
+  enable_bot_control_rule_set      = false
   enable_xss_rule_set               = true
 
   # Block specific Ukrainian regions


### PR DESCRIPTION
## atp-indexer: single-instance stack + performance fixes (tested on staging)

Collapses the atp-indexer's per-env ECS + Aurora + ALB onto one Docker-Compose EC2 box
(same pattern as the sale migration, deployed and serving prod), plus the performance fixes
that pattern surfaced. **Everything here is running on staging now**:
`api.staging.stake.aztec.network` (box, CloudFront-front) + `staging.stake.aztec.network`
(dashboard website env, restored).