### PR TITLE
Add manual payout audit URL to Nethermind provider

### DIFF
--- a/providers/6-nethermind.json
+++ b/providers/6-nethermind.json
@@ -5,5 +5,6 @@
     "providerEmail": "hello@nethermind.io",
     "providerWebsite": "https://nethermind.io",
     "providerLogoUrl": "https://avatars.githubusercontent.com/u/43478154?s=200&v=4",
-    "discordUsername": "matilote"
+    "discordUsername": "matilote",
+    "manualPayoutAuditUrl": "https://github.com/NethermindEth/aztec-staking-payout-audit"
 }


### PR DESCRIPTION
Adds our manual payout audit repository to the Nethermind provider entry.

  - **Provider:** Nethermind (id 6)
  - **manualPayoutAuditUrl:** https://github.com/NethermindEth/aztec-staking-payout-audit
  - **On-chain take rate:** 25% (2,500 bips), set via `updateProviderTakeRate(6, 2500)`
    (tx `0x913b01cb…3752daac`)

  The repo holds per-run audit JSON for every delegator distribution we make,
  so stakers can independently re-verify each payout against on-chain data
  (discovered delegators, per-checkpoint attribution, reward formula, commission,
  and the exact transfer breakdown). First published run: epochs 3972–4103.