### PR TITLE
feat: add payout audit URL for Nansen (provider 57)

### DIFF
--- a/providers/57-nansen.json
+++ b/providers/57-nansen.json
@@ -5,5 +5,6 @@
   "providerEmail": "stake@nansen.ai",
   "providerWebsite": "https://nansen.ai",
   "providerLogoUrl": "https://raw.githubusercontent.com/nansen-ai/staking-brand-assets/main/nansen_logo.svg",
-  "discordUsername": "curlycrypto"
+  "discordUsername": "curlycrypto",
+  "manualPayoutAuditUrl": "https://github.com/nansen-ai/aztec-staking-payout-audit"
 }


### PR DESCRIPTION
Adds `manualPayoutAuditUrl` for Nansen (provider 57) pointing to our public payout audit repository.