### PR TITLE
Add manual payout audit URL for provider 25

### DIFF
--- a/providers/25-snoopfear.json
+++ b/providers/25-snoopfear.json
@@ -1,9 +1,10 @@
 {
   "providerId": 25,
   "providerName": "snoopfear|PON",
-  "providerDescription": "Reliability. Performance. 24/7 monitoring. Enterprise-grade infrastructure at a fair 4% fee.",
+  "providerDescription": "Reliability. Performance. 24/7 monitoring. Enterprise-grade infrastructure at a fair fee.",
   "providerEmail": "snoopfear@proton.me",
   "providerWebsite": "https://t.me/snoopfear",
   "providerLogoUrl": "https://raw.githubusercontent.com/snoopfear/logo/refs/heads/main/my_logo.png",
-  "discordUsername": "snoopfear"
+  "discordUsername": "snoopfear",
+  "manualPayoutAuditUrl": "https://github.com/snoopfear/aztec-payout-audits"
 }


### PR DESCRIPTION
Adds `manualPayoutAuditUrl` for provider 25 so the staking dashboard can link to the public payout audit artifacts for this provider's audited off-chain payout flow.

Also updates the provider description to avoid referencing a fixed commission rate in static metadata.

Audit repo:
https://github.com/snoopfear/aztec-payout-audits

Current published ranges:
- 4015-4016
- 4017-4225