### PR TITLE
Add manual payout audit URL to Stakely provider

### DIFF
--- a/providers/47-stakely.json
+++ b/providers/47-stakely.json
@@ -4,5 +4,6 @@
     "providerDescription": "Stakely is a trusted Aztec staking provider with extensive experience operating validators on 30+ blockchains",
     "providerEmail": "admin@stakely.io",
     "providerWebsite": "https://stakely.io",
-    "providerLogoUrl": "https://img.stakely.io/brand-kit/universe/light-circle/universe_light_circle.svg"
+    "providerLogoUrl": "https://img.stakely.io/brand-kit/universe/light-circle/universe_light_circle.svg",
+    "manualPayoutAuditUrl": "https://github.com/Stakely/aztec-staking-payout-audit"
 }


### PR DESCRIPTION
Provider: Stakely (id 47)
manualPayoutAuditUrl: https://github.com/Stakely/aztec-staking-payout-audit

The repo holds per-run audit JSON for every delegator distribution we make,
so stakers can independently re-verify each payout against on-chain data
