### PR TITLE
feat: add TestInc provider (testnet)

### DIFF
--- a/providers-testnet/50-testinc.json
+++ b/providers-testnet/50-testinc.json
@@ -1,0 +1,10 @@
+{
+  "providerId": 50,
+  "providerName": "TestInc",
+  "providerDescription": "Testing provider. Do not delegate.",
+  "providerEmail": "example@example.com",
+  "providerWebsite": "https://example.com",
+  "providerLogoUrl": "",
+  "discordUsername": "",
+  "providerSelfStake": []
+}


### PR DESCRIPTION
Adds the TestInc provider metadata to `providers-testnet/`.

- **providerId:** 50
- **providerName:** TestInc
- **providerDescription:** Testing provider. Do not delegate.
- **providerEmail:** example@example.com
- **providerWebsite:** https://example.com

All other fields left empty.