### PR TITLE
providers: add manualPayoutAuditUrl for IP Stake (provider 51)

### DIFF
--- a/providers/51-ipstake.json
+++ b/providers/51-ipstake.json
@@ -5,5 +5,6 @@
     "providerEmail": "mail@ipstake.eu",
     "providerWebsite": "https://ipstake.eu",
     "providerLogoUrl": "https://ipstake.eu/assets/ip-stake-logo.svg",
-    "discordUsername": "cnupy"
+    "discordUsername": "cnupy",
+    "manualPayoutAuditUrl": "https://github.com/ipstake/aztec-payout-audits"
 }


### PR DESCRIPTION
Adds `manualPayoutAuditUrl` to the IP Stake provider metadata (provider 51).

We have moved existing delegations to the audited off-chain payout flow per
[Operator commission adjustments](https://forum.aztec.network/t/operator-commission-adjustments/8588):
sequencer coinbase now points at our distribution Safe, and delegator payouts are settled
with [aztec-staking-payout](https://github.com/AztecProtocol/aztec-staking-payout) on a monthly
cadence at the socialised 25% commission (also updated on-chain via `updateProviderTakeRate`).

Audit repo: https://github.com/ipstake/aztec-payout-audits — includes per-run audit JSON,
Safe Transaction Builder bundles, an execution log linking each run to its L1 tx, and a public
config for independent re-runs.
