### PR TITLE
fix: claim rewards pipeline uses the rollup fee asset, not the staking asset

### DIFF
--- a/staking-dashboard/src/components/ClaimAllDelegationRewardsButton/ClaimAllDelegationRewardsButton.tsx
+++ b/staking-dashboard/src/components/ClaimAllDelegationRewardsButton/ClaimAllDelegationRewardsButton.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import { useAccount } from "wagmi"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { useIsRewardsClaimable } from "@/hooks/rollup/useIsRewardsClaimable"
 import { useSplitsWarehouse } from "@/hooks/splits/useSplitsWarehouse"
 import { useTransactionCart } from "@/contexts/TransactionCartContext"
@@ -59,7 +59,7 @@ export const ClaimAllDelegationRewardsButton = ({
   onSuccess,
 }: ClaimAllDelegationRewardsButtonProps) => {
   const { address: beneficiary } = useAccount()
-  const { stakingAssetAddress: tokenAddress, decimals, symbol } = useStakingAssetTokenDetails()
+  const { feeAssetAddress: tokenAddress, decimals, symbol } = useFeeAssetTokenDetails()
   const { isRewardsClaimable } = useIsRewardsClaimable()
   const { addTransaction, checkTransactionInQueue, openCart, replaceTransactionByTx } = useTransactionCart()
 

--- a/staking-dashboard/src/components/ClaimAllRewardsModal/ClaimAllRewardsModal.tsx
+++ b/staking-dashboard/src/components/ClaimAllRewardsModal/ClaimAllRewardsModal.tsx
@@ -1,7 +1,7 @@
 import { createPortal } from "react-dom"
 import { useAccount } from "wagmi"
 import { Icon } from "@/components/Icon"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { useIsRewardsClaimable } from "@/hooks/rollup/useIsRewardsClaimable"
 import { useSplitsWarehouse } from "@/hooks/splits/useSplitsWarehouse"
 import { ClaimAllRewardsSummary } from "./ClaimAllRewardsSummary"
@@ -41,7 +41,7 @@ export const ClaimAllRewardsModal = ({
   onSuccess,
 }: ClaimAllRewardsModalProps) => {
   const { address: beneficiary } = useAccount()
-  const { symbol, decimals, stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { symbol, decimals, feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
   const { isRewardsClaimable } = useIsRewardsClaimable()
   const { addTransaction, openCart, replaceTransactionByTx } = useTransactionCart()
   const { showAlert } = useAlert()

--- a/staking-dashboard/src/components/ClaimDelegationRewardsButton/ClaimDelegationRewardsButton.tsx
+++ b/staking-dashboard/src/components/ClaimDelegationRewardsButton/ClaimDelegationRewardsButton.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "wagmi"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { useERC20Balance } from "@/hooks/erc20/useERC20Balance"
 import { useWarehouseBalance } from "@/hooks/splits/useWarehouseBalance"
 import { useSplitsWarehouse } from "@/hooks/splits/useSplitsWarehouse"
@@ -50,7 +50,7 @@ export const ClaimDelegationRewardsButton = ({
   variant = 'default'
 }: ClaimDelegationRewardsButtonProps) => {
   const { address: beneficiary } = useAccount()
-  const { stakingAssetAddress: tokenAddress, decimals, symbol } = useStakingAssetTokenDetails()
+  const { feeAssetAddress: tokenAddress, decimals, symbol } = useFeeAssetTokenDetails()
 
   const { warehouseAddress } = useSplitsWarehouse(splitContract)
   const { balance: splitContractBalance } = useERC20Balance(tokenAddress!, splitContract)

--- a/staking-dashboard/src/components/ClaimDelegationRewardsModal/ClaimDelegationRewardsModal.tsx
+++ b/staking-dashboard/src/components/ClaimDelegationRewardsModal/ClaimDelegationRewardsModal.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@/components/Icon"
 import { CopyButton } from "@/components/CopyButton"
 import { Tooltip } from "@/components/Tooltip"
 import { formatTokenAmount } from "@/utils/atpFormatters"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { ClaimDelegationRewardsButton } from "@/components/ClaimDelegationRewardsButton"
 import { useWarehouseBalance } from "@/hooks/splits/useWarehouseBalance"
 import { useCoinbaseRewardsAcrossRollups } from "@/hooks/rewards/useCoinbaseRewardsAcrossRollups"
@@ -46,7 +46,7 @@ export const ClaimDelegationRewardsModal = ({
   onSuccess
 }: ClaimDelegationRewardsModalProps) => {
   const { address: beneficiary } = useAccount()
-  const { symbol, decimals, stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { symbol, decimals, feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
 
   // Get warehouse address from split contract
   const { warehouseAddress } = useSplitsWarehouse(delegation.splitContract)

--- a/staking-dashboard/src/components/ClaimSelfStakeRewardsModal/ClaimSelfStakeRewardsModal.tsx
+++ b/staking-dashboard/src/components/ClaimSelfStakeRewardsModal/ClaimSelfStakeRewardsModal.tsx
@@ -6,7 +6,7 @@ import { formatTokenAmount, formatTokenAmountFull } from "@/utils/atpFormatters"
 import { validateAddress } from "@/utils/validateAddress"
 import { RollupRewardRow } from "./RollupRewardRow"
 import { debounce } from "@/utils/debounce"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { buildClaimSequencerRewardsTx } from "@/utils/claimCart"
 import { useIsRewardsClaimableAcrossRollups } from "@/hooks/rollup/useIsRewardsClaimableAcrossRollups"
 import { useCoinbaseRewardsAcrossRollups } from "@/hooks/rewards/useCoinbaseRewardsAcrossRollups"
@@ -42,7 +42,7 @@ export const ClaimSelfStakeRewardsModal = ({
   atp,
   onSuccess,
 }: ClaimSelfStakeRewardsModalProps) => {
-  const { symbol, decimals } = useStakingAssetTokenDetails()
+  const { symbol, decimals } = useFeeAssetTokenDetails()
   const [coinbaseAddress, setCoinbaseAddress] = useState("")
   const [hasCheckedRewards, setHasCheckedRewards] = useState(false)
   const [isDebouncing, setIsDebouncing] = useState(false)

--- a/staking-dashboard/src/contracts/abis/Rollup.ts
+++ b/staking-dashboard/src/contracts/abis/Rollup.ts
@@ -1,6 +1,19 @@
 export const RollupAbi = [
   {
     "type": "function",
+    "name": "getFeeAsset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getExitDelay",
     "inputs": [],
     "outputs": [

--- a/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
+++ b/staking-dashboard/src/hooks/atp/useAggregatedStakingData.ts
@@ -6,7 +6,7 @@ import { ERC20Abi } from '@/contracts/abis/ERC20'
 import { SplitAbi } from '@/contracts/abis/Split'
 import { SplitWarehouseAbi } from '@/contracts/abis/SplitWarehouse'
 import { calculateTotalUserShareFromSplitRewards } from '@/utils/rewardCalculations'
-import { useStakingAssetTokenDetails } from '@/hooks/stakingRegistry'
+import { useFeeAssetTokenDetails } from '@/hooks/rollup'
 import { contracts, getRollupVersions, type RollupVersion } from '@/contracts'
 import type { Address } from 'viem'
 import { stringToBigInt } from '@/utils/atpFormatters'
@@ -478,7 +478,7 @@ function parseErc20DirectStake(stake: ApiErc20DirectStake): Erc20DirectStakeBrea
  */
 export const useAggregatedStakingData = (): AggregatedStakingData => {
   const { address } = useAccount()
-  const { stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
 
   // Fetch staking data from API
   const {

--- a/staking-dashboard/src/hooks/rollup/index.ts
+++ b/staking-dashboard/src/hooks/rollup/index.ts
@@ -1,6 +1,7 @@
 export { useRollupData } from "./useRollupData";
 export { useActivationThresholdFormatted } from "./useActivationThresholdFormatted";
 export { useSequencerRewards } from "./useSequencerRewards";
+export { useFeeAssetTokenDetails } from "./useFeeAssetTokenDetails";
 export { useIsRewardsClaimable } from "./useIsRewardsClaimable";
 export { useIsRewardsClaimableAcrossRollups } from "./useIsRewardsClaimableAcrossRollups";
 export { useEjectionThreshold } from "./useEjectionThreshold";

--- a/staking-dashboard/src/hooks/rollup/useFeeAssetTokenDetails.ts
+++ b/staking-dashboard/src/hooks/rollup/useFeeAssetTokenDetails.ts
@@ -1,0 +1,56 @@
+import { useReadContract } from "wagmi"
+import { useERC20TokenDetails } from "../erc20/useERC20TokenDetails"
+import { contracts } from "../../contracts"
+import type { Address } from "viem"
+
+/**
+ * Hook to get the fee asset token details from the canonical rollup.
+ *
+ * Sequencer rewards are denominated in the rollup's FEE asset
+ * (`Rollup.getFeeAsset()`), NOT the staking asset. On mainnet the two are the
+ * same token, but on testnet they differ — using the staking asset in the
+ * claim pipeline made `Split.distribute()` distribute a zero balance while
+ * the actual fee-asset rewards sat stranded on the split contract. Any code
+ * that reads, distributes, or withdraws sequencer rewards must use this hook
+ * rather than `useStakingAssetTokenDetails`.
+ */
+export function useFeeAssetTokenDetails() {
+  const { data: feeAssetAddress, isLoading: isLoadingAddress, error: addressError } = useReadContract({
+    abi: contracts.rollup.abi,
+    address: contracts.rollup.address,
+    functionName: "getFeeAsset",
+    query: {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  })
+
+  const {
+    tokenDetails,
+    isLoading: isLoadingTokenDetails,
+    name,
+    symbol,
+    decimals,
+    totalSupply
+  } = useERC20TokenDetails(feeAssetAddress as Address)
+
+  return {
+    // Fee asset address (reward token)
+    feeAssetAddress: feeAssetAddress as Address | undefined,
+
+    // Token details
+    tokenDetails,
+    name,
+    symbol,
+    decimals,
+    totalSupply,
+
+    // Loading states
+    isLoading: isLoadingAddress || isLoadingTokenDetails,
+    isLoadingAddress,
+    isLoadingTokenDetails,
+
+    // Error handling
+    error: addressError,
+  }
+}

--- a/staking-dashboard/src/hooks/splits/useTotalSplitRewards.ts
+++ b/staking-dashboard/src/hooks/splits/useTotalSplitRewards.ts
@@ -2,7 +2,7 @@ import { useSequencerRewards } from "@/hooks/rollup/useSequencerRewards"
 import { useERC20Balance } from "@/hooks/erc20/useERC20Balance"
 import { useWarehouseBalance } from "./useWarehouseBalance"
 import { useSplitsWarehouse } from "./useSplitsWarehouse"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { calculateTotalUserShareFromSplitRewards, calculateUserShareFromTakeRate } from "@/utils/rewardCalculations"
 import type { Address } from "viem"
 
@@ -16,7 +16,7 @@ export const useTotalSplitRewards = (
   beneficiary: Address | undefined,
   providerTakeRate: number
 ) => {
-  const { stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
 
   // Get warehouse address from split contract
   const { warehouseAddress } = useSplitsWarehouse(splitContractAddress)

--- a/staking-dashboard/src/hooks/staker/useMultipleStakeWithProviderRewards.ts
+++ b/staking-dashboard/src/hooks/staker/useMultipleStakeWithProviderRewards.ts
@@ -3,7 +3,7 @@ import { useReadContracts } from 'wagmi'
 import type { Address } from 'viem'
 import { ERC20Abi } from '@/contracts/abis/ERC20'
 import { calculateTotalUserShareFromSplitRewards } from '@/utils/rewardCalculations'
-import { useStakingAssetTokenDetails } from '@/hooks/stakingRegistry'
+import { useFeeAssetTokenDetails } from '@/hooks/rollup'
 import { contracts, getRollupVersions, type RollupVersion } from '@/contracts'
 import type { Delegation } from '@/hooks/atp'
 import type { StakeWithProviderReward } from './types'
@@ -28,7 +28,7 @@ export const useMultipleStakeWithProviderRewards = ({
   delegations,
   enabled = true
 }: MultipleStakeWithProviderRewardsParams) => {
-  const { stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
 
   // Rollups enumerated oldest first. Raw version ids are uint256s; we replace
   // them with 1-based ordinals ("v1", "v2", …) for display.

--- a/staking-dashboard/src/pages/Operator/OperatorPage.tsx
+++ b/staking-dashboard/src/pages/Operator/OperatorPage.tsx
@@ -5,7 +5,7 @@ import { PageHeader } from "@/components/PageHeader"
 import { Icon } from "@/components/Icon"
 import { CopyButton } from "@/components/CopyButton"
 import { TooltipIcon } from "@/components/Tooltip"
-import { useStakingAssetTokenDetails } from "@/hooks/stakingRegistry"
+import { useFeeAssetTokenDetails } from "@/hooks/rollup"
 import { useIsRewardsClaimable } from "@/hooks/rollup/useIsRewardsClaimable"
 import {
   useConnectedOperatorIdentities,
@@ -56,7 +56,7 @@ export default function OperatorPage() {
     hasError: identitiesError,
     refetch: refetchIdentities,
   } = useConnectedOperatorIdentities()
-  const { symbol, decimals, stakingAssetAddress: tokenAddress } = useStakingAssetTokenDetails()
+  const { symbol, decimals, feeAssetAddress: tokenAddress } = useFeeAssetTokenDetails()
   const { isRewardsClaimable } = useIsRewardsClaimable()
   // Cosmetic filter — historical delegations are kept in the underlying data
   // (a now-exited delegator might still have unclaimed rollup rewards on the


### PR DESCRIPTION
## Problem

Sequencer rewards are paid in the rollup's **fee asset** — `RewardLib.claimSequencerRewards` does `rollupStore.config.feeAsset.safeTransfer(_sequencer, amount)`. The dashboard's entire claim pipeline instead used `StakingRegistry.STAKING_ASSET` as the reward token.

On mainnet `feeAsset == stakingAsset`, so this happened to work. On testnet they are different tokens ("FeeJuice" vs "Staking"), which breaks the flow:

- `claimSequencerRewards` moves FEE onto the split contract ✅
- `Split.distribute(..., STK, ...)` distributes the split's STK balance, which is **0** — the tx succeeds but distributes nothing
- the FEE rewards sit stranded on the PullSplit, and the dashboard can't even see them (the stranded-balance recovery check also reads the STK balance)

Example stuck claim on Sepolia: `0x3b5cc63dab45e00a249fb4f4af35de20f21a563a1e5dfc3e05425bb4f6ce2a05` — 5.16 FEE stranded on split `0x75592d3372aE11212e1dd47797B84797DE6Ee98C`.

## Fix

- Add `getFeeAsset` to the frontend Rollup ABI
- New `useFeeAssetTokenDetails()` hook — resolves the reward token from the canonical rollup's `getFeeAsset()`
- Swap it in for `useStakingAssetTokenDetails()` in every reward claim/read path: `ClaimDelegationRewardsButton`, `ClaimAllDelegationRewardsButton`, `ClaimAllRewardsModal`, `ClaimDelegationRewardsModal`, `ClaimSelfStakeRewardsModal`, `useAggregatedStakingData`, `useMultipleStakeWithProviderRewards`, `useTotalSplitRewards`, `OperatorPage`

Staking/deposit flows are untouched — they correctly keep using the staking asset.

## Notes

- No behavior change on mainnet (both hooks resolve to the same token there)
- Assumes all rollup versions share one fee asset (token is read from the canonical rollup only); if an old rollup version ever used a different fee asset its claims would need a per-rollup token, which the current single-token distribute/withdraw pipeline doesn't model anyway