### PR TITLE
fix: decouple dashboard deploys from retired indexer state

### DIFF
--- a/.github/workflows/deploy-staking-dashboard.yaml
+++ b/.github/workflows/deploy-staking-dashboard.yaml
@@ -6,7 +6,7 @@ on:
       environment:
         description: "Environment to deploy to"
         required: true
-        default: "staging"
+        default: "testnet"
         type: choice
         options:
           - testnet
@@ -37,9 +37,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'staging' }}
+    environment: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
     env:
-      ENV: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'staging' }}
+      ENV: ${{ inputs.environment || (contains(github.ref, '-prod') && 'prod') || 'testnet' }}
       GREEN: ${{ inputs.green || contains(github.ref, '-green') }}
       DRY_RUN: ${{ inputs.dry_run }}
 

--- a/atp-indexer/single-instance/README.md
+++ b/atp-indexer/single-instance/README.md
@@ -98,22 +98,11 @@ pull + restart adopts the existing schema and is back at head in seconds.
 ## Cutover (decommission the old fleet)
 1. Stand up this box; seed/let it reach head (the indexer is RPC-bound — see ignition's
    ROAD-TO-PROD notes; restore a `pg_dump` if you have one to skip the reindex).
-2. Repoint the **frontend's** indexer URL to this box's endpoint:
-   - **2a. Terraform state.** The frontend reads the URL from the atp-indexer's remote state
-     (`staking-dashboard/terraform/data.tf` →
-     `data.terraform_remote_state.atp-indexer.outputs.cf_domain_name`). Change that data
-     source's `key` from the old atp-indexer state (`.../backends/atp-indexer/terraform.tfstate`)
-     to this stack's state (`<env>/staking-dashboard/atp-indexer-single-instance/terraform.tfstate`).
-     This stack exposes a **`cf_domain_name`** output **in both modes** (same name as the old
-     stack), so no frontend code change beyond the state `key`:
-       - prod (CloudFront-front): `cf_domain_name` = the box's CloudFront domain.
-       - testnet (Caddy-direct): `cf_domain_name` = the indexer hostname (`si_atp_indexer_domain`,
-         which resolves to the EIP with Caddy serving Let's Encrypt TLS).
-   - **2b. Rebuild + redeploy the frontend.** The indexer URL is baked into the static build at
-     build time (`staking-dashboard/bootstrap.sh` reads `ATP_INDEXER_URL` from the terraform
-     output). So after 2a you must **rebuild and redeploy** the frontend to S3+CloudFront for it
-     to point at the new indexer — a terraform change alone is not enough. Do this only **after**
-     the box has reached parity, so the live frontend never points at an empty indexer.
+2. Rebuild + redeploy the frontend. Prod and testnet frontend deploys use the stable branded
+   endpoints directly (`api.stake.aztec.network` and `api.testnet.stake.aztec.network`), so they
+   are deliberately independent from both the retired fleet state and this stack's state. The
+   indexer URL is baked into the static build at build time; deploy only after the box has reached
+   parity so the live frontend never points at an empty indexer.
 3. After parity, tear down the old `atp-indexer/terraform` ECS service / Aurora / ALB
    (e.g. scale the service to 0, then `terraform destroy` those resources). **Snapshot the
    Aurora data first.** Keep the existing CloudFront if you prefer to repoint its origin

--- a/atp-indexer/single-instance/single-instance-cloudfront.tf
+++ b/atp-indexer/single-instance/single-instance-cloudfront.tf
@@ -119,9 +119,8 @@ output "cloudfront_domain_name" {
   value       = one(aws_cloudfront_distribution.front[*].domain_name)
 }
 
-# The staking-dashboard frontend reads `cf_domain_name` from the atp-indexer remote state
-# (staking-dashboard/terraform/data.tf) to build the indexer URL. Expose the same name in
-# BOTH modes so the frontend can be repointed at this stack's state with no output rename:
+# Retain the legacy `cf_domain_name` output name for compatibility with state consumers in
+# environments that have not moved to the stable branded endpoint convention:
 # - CloudFront-front (prod): the CloudFront distribution domain.
 # - Caddy-direct (testnet): the indexer hostname (resolves to the EIP, Caddy serves TLS).
 output "cf_domain_name" {

--- a/staking-dashboard/terraform/data.tf
+++ b/staking-dashboard/terraform/data.tf
@@ -1,4 +1,19 @@
+locals {
+  # Prod and testnet were migrated from the ECS/Aurora indexer stacks to stable,
+  # branded single-instance endpoints. Keep frontend deploys independent from
+  # the retired indexer Terraform states so deleting an old blue/green stack
+  # cannot break a dashboard release.
+  single_instance_atp_indexer_urls = {
+    prod    = "https://api.stake.aztec.network"
+    testnet = "https://api.testnet.stake.aztec.network"
+  }
+
+  uses_single_instance_atp_indexer = contains(keys(local.single_instance_atp_indexer_urls), var.env)
+}
+
 data "terraform_remote_state" "atp-indexer" {
+  count = local.uses_single_instance_atp_indexer ? 0 : 1
+
   backend = "s3"
   config = {
     bucket = "aztec-token-sale-terraform-state"
@@ -19,11 +34,14 @@ data "terraform_remote_state" "shared" {
 
 # Local references to backend service URLs
 locals {
-  atp_indexer_url         = "https://${data.terraform_remote_state.atp-indexer.outputs.cf_domain_name}"
-  cloudfront_logs_bucket  = try(data.terraform_remote_state.shared.outputs.cloudfront_logs_bucket_domain_name, "")
+  atp_indexer_url = local.uses_single_instance_atp_indexer ? (
+    local.single_instance_atp_indexer_urls[var.env]
+    ) : (
+    "https://${data.terraform_remote_state.atp-indexer[0].outputs.cf_domain_name}"
+  )
+  cloudfront_logs_bucket = try(data.terraform_remote_state.shared.outputs.cloudfront_logs_bucket_domain_name, "")
 }
 
 output "atp_indexer_url" {
   value = local.atp_indexer_url
 }
-


### PR DESCRIPTION
## Why

The testnet dashboard deploy failed because it still read `cf_domain_name` from the retired `testnet-green` ATP indexer state. That state was intentionally destroyed during the single-instance migration, so Terraform now sees an output-less state object and aborts before building the frontend.

## Fix

- use the stable branded API endpoints directly for migrated prod/testnet dashboards
- skip the retired indexer remote state for those environments
- make testnet the valid default for manual and testnet-tag deploys
- update the single-instance cutover docs to match

## Verification

- merged-main Build workflow passed
- `terraform validate` passed
- real testnet plan passed with `indexer_deployment_suffix=-green`
- plan changes zero AWS resources; only `atp_indexer_url` changes from the retired CloudFront hostname to `https://api.testnet.stake.aztec.network`
- live testnet API `/ready` and `/api/providers` return 200